### PR TITLE
Extending AbstractSurrogate interface

### DIFF
--- a/.JuliaFormatter.toml
+++ b/.JuliaFormatter.toml
@@ -1,0 +1,1 @@
+style = "sciml"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,36 @@
+name: CI
+on:
+  push:
+    branches:
+    tags: ['*']
+  pull_request:
+  workflow_dispatch:
+concurrency:
+  # Skip intermediate builds: always.
+  # Cancel intermediate builds: only if it is a pull request build.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+jobs:
+  test:
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - '1.0'
+          - '1.8'
+          - 'nightly'
+        os:
+          - ubuntu-latest
+        arch:
+          - x64
+    steps:
+      - uses: actions/checkout@v3
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
+      - uses: julia-actions/cache@v1
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-runtest@v1

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,36 +1,43 @@
 name: CI
 on:
+  pull_request:
+    branches:
+      - master
   push:
     branches:
-    tags: ['*']
-  pull_request:
-  workflow_dispatch:
-concurrency:
-  # Skip intermediate builds: always.
-  # Cancel intermediate builds: only if it is a pull request build.
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+      - master
 jobs:
   test:
-    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.group == 'Downstream' }}
     strategy:
       fail-fast: false
       matrix:
+        group:
+          - Core
         version:
-          - '1.0'
-          - '1.8'
-          - 'nightly'
-        os:
-          - ubuntu-latest
-        arch:
-          - x64
+          - '1'
+          - '1.6'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v1
         with:
           version: ${{ matrix.version }}
-          arch: ${{ matrix.arch }}
-      - uses: julia-actions/cache@v1
+      - uses: actions/cache@v3
+        env:
+          cache-name: cache-artifacts
+        with:
+          path: ~/.julia/artifacts
+          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-test-${{ env.cache-name }}-
+            ${{ runner.os }}-test-
+            ${{ runner.os }}-
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
+        env:
+          GROUP: ${{ matrix.group }}
+      - uses: julia-actions/julia-processcoverage@v1
+      - uses: codecov/codecov-action@v3
+        with:
+          file: lcov.info

--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -1,0 +1,16 @@
+name: CompatHelper
+on:
+  schedule:
+    - cron: 0 0 * * *
+  workflow_dispatch:
+jobs:
+  CompatHelper:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Pkg.add("CompatHelper")
+        run: julia -e 'using Pkg; Pkg.add("CompatHelper")'
+      - name: CompatHelper.main()
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMPATHELPER_PRIV: ${{ secrets.DOCUMENTER_KEY }}
+        run: julia -e 'using CompatHelper; CompatHelper.main()'

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -1,0 +1,42 @@
+name: format-check
+
+on:
+  push:
+    branches:
+      - 'master'
+      - 'release-'
+    tags: '*'
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        julia-version: [1]
+        julia-arch: [x86]
+        os: [ubuntu-latest]
+    steps:
+      - uses: julia-actions/setup-julia@latest
+        with:
+          version: ${{ matrix.julia-version }}
+
+      - uses: actions/checkout@v3
+      - name: Install JuliaFormatter and format
+        # This will use the latest version by default but you can set the version like so:
+        #
+        # julia  -e 'using Pkg; Pkg.add(PackageSpec(name="JuliaFormatter", version="0.13.0"))'
+        run: |
+          julia  -e 'using Pkg; Pkg.add(PackageSpec(name="JuliaFormatter"))'
+          julia  -e 'using JuliaFormatter; format(".", verbose=true)'
+      - name: Format check
+        run: |
+          julia -e '
+          out = Cmd(`git diff`) |> read |> String
+          if out == ""
+              exit(0)
+          else
+              @error "Some files have not been formatted !!!"
+              write(stdout, out)
+              exit(1)
+          end'

--- a/.github/workflows/Invalidations.yml
+++ b/.github/workflows/Invalidations.yml
@@ -1,0 +1,40 @@
+name: Invalidations
+
+on:
+  pull_request:
+
+concurrency:
+  # Skip intermediate builds: always.
+  # Cancel intermediate builds: always.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  evaluate:
+    # Only run on PRs to the default branch.
+    # In the PR trigger above branches can be specified only explicitly whereas this check should work for master, main, or any other default branch
+    if: github.base_ref == github.event.repository.default_branch
+    runs-on: ubuntu-latest
+    steps:
+    - uses: julia-actions/setup-julia@v1
+      with:
+        version: '1'
+    - uses: actions/checkout@v3
+    - uses: julia-actions/julia-buildpkg@v1
+    - uses: julia-actions/julia-invalidations@v1
+      id: invs_pr
+
+    - uses: actions/checkout@v3
+      with:
+        ref: ${{ github.event.repository.default_branch }}
+    - uses: julia-actions/julia-buildpkg@v1
+    - uses: julia-actions/julia-invalidations@v1
+      id: invs_default
+    
+    - name: Report invalidation counts
+      run: |
+        echo "Invalidations on default branch: ${{ steps.invs_default.outputs.total }} (${{ steps.invs_default.outputs.deps }} via deps)" >> $GITHUB_STEP_SUMMARY
+        echo "This branch: ${{ steps.invs_pr.outputs.total }} (${{ steps.invs_pr.outputs.deps }} via deps)" >> $GITHUB_STEP_SUMMARY
+    - name: Check if the PR does increase number of invalidations
+      if: steps.invs_pr.outputs.total > steps.invs_default.outputs.total
+      run: exit 1

--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -1,0 +1,31 @@
+name: TagBot
+on:
+  issue_comment:
+    types:
+      - created
+  workflow_dispatch:
+    inputs:
+      lookback:
+        default: 3
+permissions:
+  actions: read
+  checks: read
+  contents: write
+  deployments: read
+  issues: read
+  discussions: read
+  packages: read
+  pages: read
+  pull-requests: read
+  repository-projects: read
+  security-events: read
+  statuses: read
+jobs:
+  TagBot:
+    if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: JuliaRegistries/TagBot@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          ssh: ${{ secrets.DOCUMENTER_KEY }}

--- a/Project.toml
+++ b/Project.toml
@@ -3,6 +3,9 @@ uuid = "89f642e6-4179-4274-8202-c11f4bd9a72c"
 authors = ["Samuel Belko <samuelbelko@protonmail.com> and contributors"]
 version = "1.0.0-DEV"
 
+[deps]
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+
 [compat]
 julia = "1"
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,13 @@
+name = "SurrogatesBase"
+uuid = "89f642e6-4179-4274-8202-c11f4bd9a72c"
+authors = ["Samuel Belko <samuelbelko@protonmail.com> and contributors"]
+version = "1.0.0-DEV"
+
+[compat]
+julia = "1"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "1.0.0-DEV"
 
 [deps]
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
 julia = "1"

--- a/src/SurrogatesBase.jl
+++ b/src/SurrogatesBase.jl
@@ -7,11 +7,7 @@ import Base: rand
 export AbstractSurrogate,
     add_point!,
     update_hyperparameters!, hyperparameters,
-    posterior,
-    mean,
-    var,
-    rand,
-    logpdf
+    posterior, mean, var, rand, logpdf
 
 abstract type AbstractSurrogate <: Function end
 
@@ -35,8 +31,10 @@ Add evaluations `new_ys` at points `new_xs` to the surrogate.
 
 Use `add_point!(s, eachslice(X, dims = 2), new_ys)` if `X` is a matrix.
 """
-function add_point!(s::AbstractSurrogate, new_xs::AbstractVector{<:AbstractVector}, new_ys::AbstractVector)
-    add_point!.(Ref(s), new_xs, new_ys )
+function add_point!(s::AbstractSurrogate,
+    new_xs::AbstractVector{<:AbstractVector},
+    new_ys::AbstractVector)
+    add_point!.(Ref(s), new_xs, new_ys)
 end
 
 """
@@ -111,14 +109,14 @@ end
 
 Return a sample from the joint posterior at points `xs`.
 """
-function rand(s::AbstractSurrogate, xs::AbstractVector{<:AbstractVector})  end
+function rand(s::AbstractSurrogate, xs::AbstractVector{<:AbstractVector}) end
 
 """
     rand(s::AbstractSurrogate, x::AbstractVector)
 
 Return a sample from the posterior distribution at a point `x`.
 """
-function rand(s::AbstractSurrogate, x::AbstractVector) = only(rand(s::AbstractSurrogate, [x]))
+rand(s::AbstractSurrogate, x::AbstractVector) = only(rand(s::AbstractSurrogate, [x]))
 
 """
     logpdf(s::AbstractSurrogate)

--- a/src/SurrogatesBase.jl
+++ b/src/SurrogatesBase.jl
@@ -1,0 +1,87 @@
+module SurrogatesBase
+
+# AbstractSurrogate interface
+export AbstractSurrogate,
+    add_point!, add_points!,
+    supports_hyperparameters, update_hyperparameters!, hyperparameters,
+    supports_posterior, posterior
+
+abstract type AbstractSurrogate <: Function end
+
+"""
+    (s::AbstractSurrogate)(x)
+
+Compute an approximation at `x`.
+"""
+function (s::AbstractSurrogate)(x) end
+
+"""
+    add_point!(s::AbstractSurrogate, new_x, new_y)
+
+Add an evaluation `new_y` at point `new_x` to the surrogate.
+
+See also [`add_points!`](@ref).
+"""
+function add_point!(s::AbstractSurrogate, new_x, new_y) end
+"""
+    add_points!(s::AbstractSurrogate, new_xs, new_ys)
+
+Add evaluations `new_ys` at points `new_xs` to the surrogate.
+
+See also [`add_point!`](@ref).
+"""
+function add_points!(s::AbstractSurrogate, new_xs, new_ys)
+    length(new_xs) == length(new_ys) ||
+        throw(ArgumentError("new_xs, new_ys have different lengths"))
+    for (x, y) in zip(new_xs, new_ys)
+        add_point!(s, x, y)
+    end
+end
+
+"""
+    supports_hyperparameters(s::AbstractSurrogate)
+
+Return `true` if `s` supports hyperparameters, otherwise return `false`.
+
+See also [`update_hyperparameters!`](@ref), [`hyperparameters`](@ref).
+"""
+supports_hyperparameters(s::AbstractSurrogate) = false
+"""
+    update_hyperparameters!(s::AbstractSurrogate, prior)
+
+If `s` supports hyperparameters, use `prior` to perform an update.
+
+See also [`supports_hyperparameters`](@ref),  [`hyperparameters`](@ref).
+"""
+function update_hyperparameters!(s::AbstractSurrogate, prior)
+    error("update_hyperparameters! is not implemented")
+end
+
+"""
+    hyperparameters(s::AbstractSurrogate)
+
+Return a `NamedTuple`, where names are hyperparameters and values are currently used
+values of hyperparameters by `s`.
+
+See also [`supports_hyperparameters`](@ref),  [`update_hyperparameters!`](@ref).
+"""
+function hyperparameters(s::AbstractSurrogate)
+    error("access to hyperparameters is not implemented")
+end
+
+"""
+    supports_posterior(s::AbstractSurrogate)
+
+Return `true`, if `s` can provide joint posterior distribution, otherwise return `false`.
+
+See also [`posterior`](@ref).
+"""
+supports_posterior(s::AbstractSurrogate) = false
+"""
+    posterior(s::AbstractSurrogate, x)
+
+Return a joint posterior at `x = [x_1, ..., x_m]`.
+"""
+posterior(s::AbstractSurrogate, x) = error("posterior is not implemented")
+
+end

--- a/src/SurrogatesBase.jl
+++ b/src/SurrogatesBase.jl
@@ -9,17 +9,34 @@ export AbstractSurrogate,
     update_hyperparameters!, hyperparameters,
     posterior, mean, var, rand, logpdf
 
+"""
+    abstract type AbstractSurrogate end
+
+An abstract type for defining surrogate interface.
+
+    (s::AbstractSurrogate)(x::AbstractVector)
+
+Subtypes of `AbstractSurrogate` need to be callable with input points `x` that returns
+an approximation at `x`, i.e., evaluates the surrogate at `x`.
+
+ # Examples
+ ```jldoctest
+ julia> struct ZeroSurrogate <: AbstractSurrogate end
+
+ julia> (::ZeroSurrogate)(x::AbstractVector) = 0
+
+ julia> s = ZeroSurrogate()
+ ZeroSurrogate()
+
+ julia> s(rand(5)) == 0
+ true
+ ```
+ """
 abstract type AbstractSurrogate <: Function end
 
 """
-    (s::AbstractSurrogate)(x::AbstractVector)
-
-Compute an approximation at point `x`.
-"""
-function (s::AbstractSurrogate)(x::AbstractVector) end
-
-"""
-    add_point!(s::AbstractSurrogate, new_x::AbstractVector, new_y)
+    add_point!(s::AbstractSurrogate, new_x::AbstractVector, new_y::Number)
+    add_point!(s::AbstractSurrogate, new_x::Union{AbstractVector, Number}, new_y::Number)
 
 Add an evaluation `new_y` at point `new_x` to the surrogate.
 """

--- a/src/SurrogatesBase.jl
+++ b/src/SurrogatesBase.jl
@@ -2,12 +2,11 @@ module SurrogatesBase
 
 import Statistics: mean, var
 import Base: rand
-import StatsBase.mean_and_var
+import StatsBase: mean_and_var
 
-export AbstractSurrogate,
-    add_point!,
-    update_hyperparameters!, hyperparameters,
-    mean, var, rand, mean_and_var
+export AbstractSurrogate, add_point!
+export update_hyperparameters!, hyperparameters
+export mean, var, mean_and_var, rand
 
 """
     abstract type AbstractSurrogate{D, R} end
@@ -108,20 +107,6 @@ function var(s::AbstractSurrogate{D}, xs::AbstractVector{D}) where {D}
 end
 
 """
-    rand(s::AbstractSurrogate{D}, xs::AbstractVector{D}) where D
-
-Return a sample from the joint posterior at points `xs`.
-"""
-function rand end
-
-"""
-    rand(s::AbstractSurrogate{D}, x::D) where D
-
-Return a sample from the posterior distribution at a point `x`.
-"""
-rand(s::AbstractSurrogate{D}, x::D) where {D} = only(rand(s::AbstractSurrogate, [x]))
-
-"""
     mean_and_var(s::AbstractSurrogate{D}, x::D) where D
 
 Return a Tuple of mean and variance at point `x`.
@@ -138,5 +123,19 @@ Return a Tuple of vector of means and vector of variances at points `xs`.
 function mean_and_var(s::AbstractSurrogate{D}, xs::AbstractVector{D}) where {D}
     mean(s, xs), var(s, xs)
 end
+
+"""
+    rand(s::AbstractSurrogate{D}, xs::AbstractVector{D}) where D
+
+Return a sample from the joint posterior at points `xs`.
+"""
+function rand end
+
+"""
+    rand(s::AbstractSurrogate{D}, x::D) where D
+
+Return a sample from the posterior distribution at a point `x`.
+"""
+rand(s::AbstractSurrogate{D}, x::D) where {D} = only(rand(s::AbstractSurrogate, [x]))
 
 end

--- a/src/SurrogatesBase.jl
+++ b/src/SurrogatesBase.jl
@@ -126,8 +126,8 @@ rand(s::AbstractSurrogate{D}, x::D) where {D} = only(rand(s::AbstractSurrogate, 
 
 Return a Tuple of mean and variance at point `x`.
 """
-function mean_and_var(s::AbstractSurrogate{D}, x::D) where D
-    mean(s,x), var(s,x)
+function mean_and_var(s::AbstractSurrogate{D}, x::D) where {D}
+    mean(s, x), var(s, x)
 end
 
 """
@@ -135,8 +135,8 @@ end
 
 Return a Tuple of vector of means and vector of variances at points `xs`.
 """
-function mean_and_var(s::AbstractSurrogate{D}, xs::AbstractVector{D}) where D
-    mean(s,xs), var(s,xs)
+function mean_and_var(s::AbstractSurrogate{D}, xs::AbstractVector{D}) where {D}
+    mean(s, xs), var(s, xs)
 end
 
 end

--- a/src/SurrogatesBase.jl
+++ b/src/SurrogatesBase.jl
@@ -6,7 +6,7 @@ import Base: rand
 export AbstractSurrogate,
     add_point!,
     update_hyperparameters!, hyperparameters,
-    posterior, mean, var, rand, logpdf
+    posterior, mean, var, rand
 
 """
     abstract type AbstractSurrogate{D, R} end
@@ -133,12 +133,5 @@ function rand end
 Return a sample from the posterior distribution at a point `x`.
 """
 rand(s::AbstractSurrogate{D}, x::D) where D = only(rand(s::AbstractSurrogate, [x]))
-
-"""
-    logpdf(s::AbstractSurrogate)
-
-Return a log marginal posterior predictive probability.
-"""
-function logpdf end
 
 end

--- a/src/SurrogatesBase.jl
+++ b/src/SurrogatesBase.jl
@@ -16,8 +16,9 @@ range type `R` of the underlying function that is being approximated.
 
     (s::AbstractSurrogate{D})(x::D) where D
 
-Subtypes of `AbstractSurrogate` need to be callable with input points `x` such that the result
-is an evaluation of the surrogate at `x`.
+Subtypes of `AbstractSurrogate` can be callable with input points `x` such that the result
+is an evaluation of the surrogate at `x`, corresponding to an approximation of the underlying
+function at `x`.
 
  # Examples
  ```jldoctest

--- a/src/SurrogatesBase.jl
+++ b/src/SurrogatesBase.jl
@@ -85,7 +85,7 @@ function posterior end
 
 Return posterior at point `x`.
 """
-posterior(s::AbstractSurrogate{D}, x::D) where D = posterior(s, [x])
+posterior(s::AbstractSurrogate{D}, x::D) where {D} = posterior(s, [x])
 
 """
     mean(s::AbstractSurrogate{D}, x::D) where D
@@ -100,7 +100,7 @@ Return a vector of means at points `xs`.
 
 Use `mean(s, eachslice(X, dims = 2))` if `X` is a matrix.
 """
-function mean(s::AbstractSurrogate{D}, xs::AbstractVector{D}) where D
+function mean(s::AbstractSurrogate{D}, xs::AbstractVector{D}) where {D}
     mean.(Ref(s), xs)
 end
 
@@ -116,7 +116,7 @@ function var end
 
 Return a vector of variances at points `xs`.
 """
-function var(s::AbstractSurrogate{D}, xs::AbstractVector{D}) where D
+function var(s::AbstractSurrogate{D}, xs::AbstractVector{D}) where {D}
     var.(Ref(s), xs)
 end
 
@@ -132,6 +132,6 @@ function rand end
 
 Return a sample from the posterior distribution at a point `x`.
 """
-rand(s::AbstractSurrogate{D}, x::D) where D = only(rand(s::AbstractSurrogate, [x]))
+rand(s::AbstractSurrogate{D}, x::D) where {D} = only(rand(s::AbstractSurrogate, [x]))
 
 end

--- a/src/SurrogatesBase.jl
+++ b/src/SurrogatesBase.jl
@@ -3,8 +3,12 @@ module SurrogatesBase
 # AbstractSurrogate interface
 export AbstractSurrogate,
     add_point!, add_points!,
-    supports_hyperparameters, update_hyperparameters!, hyperparameters,
-    supports_posterior, posterior
+    update_hyperparameters!, hyperparameters,
+    posterior, posterior_at_point,
+    mean, mean_at_point
+    var, var_at_point,
+    rand, rand_at_point,
+    logpdf
 
 abstract type AbstractSurrogate <: Function end
 
@@ -39,19 +43,11 @@ function add_points!(s::AbstractSurrogate, new_xs, new_ys)
 end
 
 """
-    supports_hyperparameters(s::AbstractSurrogate)
-
-Return `true` if `s` supports hyperparameters, otherwise return `false`.
-
-See also [`update_hyperparameters!`](@ref), [`hyperparameters`](@ref).
-"""
-supports_hyperparameters(s::AbstractSurrogate) = false
-"""
     update_hyperparameters!(s::AbstractSurrogate, prior)
 
 If `s` supports hyperparameters, use `prior` to perform an update.
 
-See also [`supports_hyperparameters`](@ref),  [`hyperparameters`](@ref).
+See also [`hyperparameters`](@ref).
 """
 function update_hyperparameters!(s::AbstractSurrogate, prior)
     error("update_hyperparameters! is not implemented")
@@ -63,25 +59,68 @@ end
 Return a `NamedTuple`, where names are hyperparameters and values are currently used
 values of hyperparameters by `s`.
 
-See also [`supports_hyperparameters`](@ref),  [`update_hyperparameters!`](@ref).
+See also [`update_hyperparameters!`](@ref).
 """
 function hyperparameters(s::AbstractSurrogate)
     error("access to hyperparameters is not implemented")
 end
 
 """
-    supports_posterior(s::AbstractSurrogate)
-
-Return `true`, if `s` can provide joint posterior distribution, otherwise return `false`.
-
-See also [`posterior`](@ref).
-"""
-supports_posterior(s::AbstractSurrogate) = false
-"""
     posterior(s::AbstractSurrogate, x)
 
-Return a joint posterior at `x = [x_1, ..., x_m]`.
+Return a joint posterior at `m` points in `x = [x_1, ..., x_m]`.
 """
 posterior(s::AbstractSurrogate, x) = error("posterior is not implemented")
+
+"""
+    posterior_at_point(s::AbstractSurrogate, x)
+
+Return a posterior at point `x`.
+"""
+posterior_at_point(s::AbstractSurrogate, x) = posterior(s, [x])
+
+"""
+    mean(s::AbstractSurrogate, x)
+
+For `m` points in `x = [x_1, ..., x_m]`, return a vector of means `[μ_at_x_1, ..., μ_at_x_m]`.
+"""
+function mean(s::AbstractSurrogate, x) end
+
+"""
+    mean_at_point(s::AbstractSurrogate, x)
+
+For a point `x`, return a mean at `x`.
+"""
+mean_at_point(s::AbstractSurrogate, x) = only(mean(s, [x]))
+"""
+    var(s::AbstractSurrogate, x)
+
+For `m` points in `x = [x_1, ..., x_m]`, return a vector of variances `[σ²_at_x_1, ..., σ²_at_x_m]`
+"""
+function var(s::AbstractSurrogate, x) end
+"""
+    var_at_point(s::AbstractSurrogate, x)
+
+For a point `x`, return a variance at `x`.
+"""
+var_at_point(s::AbstractSurrogate, x) = only(var(s, [x]))
+"""
+    rand(s::AbstractSurrogate, x)
+
+Sample from a joint posterior distribution at `m` points in `x = [x_1, ..., x_m]`.
+"""
+function rand(s::AbstractSurrogate, x) = end
+"""
+    rand_at_point(s::AbstractSurrogate, x)
+
+Sample from a posterior distribution at a point `x`.
+"""
+rand_at_point(s::AbstractSurrogate, x) = rand(s::AbstractSurrogate, [x])
+"""
+    logpdf(s::AbstractSurrogate)
+
+Log marginal posterior predictive probability.
+"""
+function logpdf(s::AbstractSurrogate) end
 
 end

--- a/src/SurrogatesBase.jl
+++ b/src/SurrogatesBase.jl
@@ -12,7 +12,7 @@ export AbstractSurrogate,
 abstract type AbstractSurrogate <: Function end
 
 """
-    (s::AbstractSurrogate)(x)
+    (s::AbstractSurrogate)(x::AbstractVector)
 
 Compute an approximation at point `x`.
 """
@@ -23,7 +23,7 @@ function (s::AbstractSurrogate)(x::AbstractVector) end
 
 Add an evaluation `new_y` at point `new_x` to the surrogate.
 """
-function add_point!(s::AbstractSurrogate, new_x::AbstractVector, new_y) end
+function add_point! end
 """
     add_point!(s::AbstractSurrogate, new_xs::AbstractVector{<:AbstractVector}, new_ys::AbstractVector)
 
@@ -44,7 +44,7 @@ Use prior on hyperparameters passed in `prior` to perform an update.
 
 See also [`hyperparameters`](@ref).
 """
-function update_hyperparameters!(s::AbstractSurrogate, prior) end
+function update_hyperparameters! end
 
 """
     hyperparameters(s::AbstractSurrogate)
@@ -54,7 +54,7 @@ values of hyperparameters in `s`.
 
 See also [`update_hyperparameters!`](@ref).
 """
-function hyperparameters(s::AbstractSurrogate) end
+function hyperparameters end
 
 """
     posterior(s::AbstractSurrogate, xs::AbstractVector{<:AbstractVector})
@@ -63,7 +63,7 @@ Return a joint posterior at points `xs`.
 
 Use `posterior(s, eachslice(X, dims = 2))` if `X` is a matrix.
 """
-function posterior(s::AbstractSurrogate, xs::AbstractVector{<:AbstractVector}) end
+function posterior end
 """
     posterior(s::AbstractSurrogate, x::AbstractVector)
 
@@ -76,7 +76,7 @@ posterior(s::AbstractSurrogate, x::AbstractVector) = posterior(s, [x])
 
 Return mean at point `x`.
 """
-function mean(s::AbstractSurrogate, x::AbstractVector) end
+function mean end
 """
     mean(s::AbstractSurrogate, xs::AbstractVector{<:AbstractVector})
 
@@ -93,7 +93,7 @@ end
 
 Return variance at point `x`.
 """
-function var(s::AbstractSurrogate, x::AbstractVector) end
+function var end
 
 """
     var(s::AbstractSurrogate, xs::AbstractVector{<:AbstractVector})
@@ -109,7 +109,7 @@ end
 
 Return a sample from the joint posterior at points `xs`.
 """
-function rand(s::AbstractSurrogate, xs::AbstractVector{<:AbstractVector}) end
+function rand end
 
 """
     rand(s::AbstractSurrogate, x::AbstractVector)
@@ -123,6 +123,6 @@ rand(s::AbstractSurrogate, x::AbstractVector) = only(rand(s::AbstractSurrogate, 
 
 Return a log marginal posterior predictive probability.
 """
-function logpdf(s::AbstractSurrogate) end
+function logpdf end
 
 end

--- a/src/SurrogatesBase.jl
+++ b/src/SurrogatesBase.jl
@@ -20,19 +20,19 @@ Subtypes of `AbstractSurrogate` can be callable with input points `x` such that 
 is an evaluation of the surrogate at `x`, corresponding to an approximation of the underlying
 function at `x`.
 
- # Examples
- ```jldoctest
- julia> struct ZeroSurrogate{D, R} <: AbstractSurrogate{D, R} end
+# Examples
+```jldoctest
+julia> struct ZeroSurrogate{D, R} <: AbstractSurrogate{D, R} end
 
- julia> (::ZeroSurrogate{D})(x::D) where D = 0
+julia> (::ZeroSurrogate{D})(x::D) where D = 0
 
- julia> s = ZeroSurrogate{Int, Int}()
- ZeroSurrogate{Int64, Int64}()
+julia> s = ZeroSurrogate{Int, Int}()
+ZeroSurrogate{Int64, Int64}()
 
- julia> s(4) == 0
- true
- ```
- """
+julia> s(4) == 0
+true
+```
+"""
 abstract type AbstractSurrogate{D, R} <: Function end
 
 """

--- a/src/SurrogatesBase.jl
+++ b/src/SurrogatesBase.jl
@@ -2,11 +2,12 @@ module SurrogatesBase
 
 import Statistics: mean, var
 import Base: rand
+import StatsBase.mean_and_var
 
 export AbstractSurrogate,
     add_point!,
     update_hyperparameters!, hyperparameters,
-    posterior, mean, var, rand
+    mean, var, rand, mean_and_var
 
 """
     abstract type AbstractSurrogate{D, R} end
@@ -74,21 +75,6 @@ See also [`update_hyperparameters!`](@ref).
 function hyperparameters end
 
 """
-    posterior(s::AbstractSurrogate{D}, xs::AbstractVector{D}) where D
-
-Return a joint posterior at points `xs`.
-
-Use `posterior(s, eachslice(X, dims = 2))` if `X` is a matrix.
-"""
-function posterior end
-"""
-    posterior(s::AbstractSurrogate{D}, x::D) where D
-
-Return posterior at point `x`.
-"""
-posterior(s::AbstractSurrogate{D}, x::D) where {D} = posterior(s, [x])
-
-"""
     mean(s::AbstractSurrogate{D}, x::D) where D
 
 Return mean at point `x`.
@@ -134,5 +120,23 @@ function rand end
 Return a sample from the posterior distribution at a point `x`.
 """
 rand(s::AbstractSurrogate{D}, x::D) where {D} = only(rand(s::AbstractSurrogate, [x]))
+
+"""
+    mean_and_var(s::AbstractSurrogate{D}, x::D) where D
+
+Return a Tuple of mean and variance at point `x`.
+"""
+function mean_and_var(s::AbstractSurrogate{D}, x::D) where D
+    mean(s,x), var(s,x)
+end
+
+"""
+    mean_and_var(s::AbstractSurrogate{D}, xs::AbstractVector{D}) where D
+
+Return a Tuple of vector of means and vector of variances at points `xs`.
+"""
+function mean_and_var(s::AbstractSurrogate{D}, xs::AbstractVector{D}) where D
+    mean(s,xs), var(s,xs)
+end
 
 end

--- a/src/SurrogatesBase.jl
+++ b/src/SurrogatesBase.jl
@@ -3,54 +3,53 @@ module SurrogatesBase
 import Statistics: mean, var
 import Base: rand
 
-# AbstractSurrogate interface
 export AbstractSurrogate,
     add_point!,
     update_hyperparameters!, hyperparameters,
     posterior, mean, var, rand, logpdf
 
 """
-    abstract type AbstractSurrogate end
+    abstract type AbstractSurrogate{D, R} end
 
-An abstract type for defining surrogate interface.
+An abstract type for surrogate interface, parametrized by domain type `D` and
+range type `R` of the underlying function that is being approximated.
 
-    (s::AbstractSurrogate)(x::AbstractVector)
+    (s::AbstractSurrogate{D, R})(x::D) where {D, R}
 
-Subtypes of `AbstractSurrogate` need to be callable with input points `x` that returns
-an approximation at `x`, i.e., evaluates the surrogate at `x`.
+Subtypes of `AbstractSurrogate` need to be callable with input points `x` that
+evaluates the surrogate at `x`.
 
  # Examples
  ```jldoctest
- julia> struct ZeroSurrogate <: AbstractSurrogate end
+ julia> struct ZeroSurrogate{D, R} <: AbstractSurrogate{D, R} end
 
- julia> (::ZeroSurrogate)(x::AbstractVector) = 0
+ julia> (::ZeroSurrogate{D,R})(x::D) where {D,R} = 0
 
- julia> s = ZeroSurrogate()
- ZeroSurrogate()
+ julia> s = ZeroSurrogate{Int, Int}()
+ ZeroSurrogate{Int64, Int64}()
 
- julia> s(rand(5)) == 0
+ julia> s(4) == 0
  true
  ```
  """
-abstract type AbstractSurrogate <: Function end
+abstract type AbstractSurrogate{D, R} <: Function end
 
 """
-    add_point!(s::AbstractSurrogate, new_x::AbstractVector, new_y::Number)
-    add_point!(s::AbstractSurrogate, new_x::Union{AbstractVector, Number}, new_y::Number)
+    add_point!(s::AbstractSurrogate{D, R}, new_x::D, new_y::R) where {D, R}
 
 Add an evaluation `new_y` at point `new_x` to the surrogate.
 """
 function add_point! end
 """
-    add_point!(s::AbstractSurrogate, new_xs::AbstractVector{<:AbstractVector}, new_ys::AbstractVector)
+    add_point!(s::AbstractSurrogate{D, R}, new_xs::AbstractVector{D}, new_ys::AbstractVector{R}) where {D, R}
 
 Add evaluations `new_ys` at points `new_xs` to the surrogate.
 
 Use `add_point!(s, eachslice(X, dims = 2), new_ys)` if `X` is a matrix.
 """
-function add_point!(s::AbstractSurrogate,
-    new_xs::AbstractVector{<:AbstractVector},
-    new_ys::AbstractVector)
+function add_point!(s::AbstractSurrogate{D, R},
+    new_xs::AbstractVector{D},
+    new_ys::AbstractVector{R}) where {D, R}
     add_point!.(Ref(s), new_xs, new_ys)
 end
 
@@ -74,7 +73,7 @@ See also [`update_hyperparameters!`](@ref).
 function hyperparameters end
 
 """
-    posterior(s::AbstractSurrogate, xs::AbstractVector{<:AbstractVector})
+    posterior(s::AbstractSurrogate{D, R}, xs::AbstractVector{D}) where {D, R}
 
 Return a joint posterior at points `xs`.
 
@@ -82,58 +81,58 @@ Use `posterior(s, eachslice(X, dims = 2))` if `X` is a matrix.
 """
 function posterior end
 """
-    posterior(s::AbstractSurrogate, x::AbstractVector)
+    posterior(s::AbstractSurrogate{D, R}, x::D) where {D, R}
 
 Return posterior at point `x`.
 """
-posterior(s::AbstractSurrogate, x::AbstractVector) = posterior(s, [x])
+posterior(s::AbstractSurrogate{D, R}, x::D) where {D, R} = posterior(s, [x])
 
 """
-    mean(s::AbstractSurrogate, x::AbstractVector)
+    mean(s::AbstractSurrogate{D, R}, x::D) where {D, R}
 
 Return mean at point `x`.
 """
 function mean end
 """
-    mean(s::AbstractSurrogate, xs::AbstractVector{<:AbstractVector})
+    mean(s::AbstractSurrogate{D, R}, xs::AbstractVector{D}) where {D, R}
 
 Return a vector of means at points `xs`.
 
 Use `mean(s, eachslice(X, dims = 2))` if `X` is a matrix.
 """
-function mean(s::AbstractSurrogate, xs::AbstractVector{<:AbstractVector})
+function mean(s::AbstractSurrogate{D, R}, xs::AbstractVector{D}) where {D, R}
     mean.(Ref(s), xs)
 end
 
 """
-    var(s::AbstractSurrogate, x::AbstractVector)
+    var(s::AbstractSurrogate{D, R}, x::D) where {D, R}
 
 Return variance at point `x`.
 """
 function var end
 
 """
-    var(s::AbstractSurrogate, xs::AbstractVector{<:AbstractVector})
+    var(s::AbstractSurrogate{D, R}, xs::AbstractVector{D}) where {D, R}
 
 Return a vector of variances at points `xs`.
 """
-function var(s::AbstractSurrogate, xs::AbstractVector{<:AbstractVector})
+function var(s::AbstractSurrogate{D, R}, xs::AbstractVector{D}) where {D, R}
     var.(Ref(s), xs)
 end
 
 """
-    rand(s::AbstractSurrogate, xs::AbstractVector{<:AbstractVector})
+    rand(s::AbstractSurrogate{D, R}, xs::AbstractVector{D}) where {D, R}
 
 Return a sample from the joint posterior at points `xs`.
 """
 function rand end
 
 """
-    rand(s::AbstractSurrogate, x::AbstractVector)
+    rand(s::AbstractSurrogate{D,R}, x::D)
 
 Return a sample from the posterior distribution at a point `x`.
 """
-rand(s::AbstractSurrogate, x::AbstractVector) = only(rand(s::AbstractSurrogate, [x]))
+rand(s::AbstractSurrogate{D, R}, x::D) where {D, R}= only(rand(s::AbstractSurrogate, [x]))
 
 """
     logpdf(s::AbstractSurrogate)

--- a/src/SurrogatesBase.jl
+++ b/src/SurrogatesBase.jl
@@ -11,13 +11,13 @@ export AbstractSurrogate,
 """
     abstract type AbstractSurrogate{D, R} end
 
-An abstract type for surrogate interface, parametrized by domain type `D` and
+An abstract type for surrogates, parametrized by domain type `D` and
 range type `R` of the underlying function that is being approximated.
 
     (s::AbstractSurrogate{D, R})(x::D) where {D, R}
 
-Subtypes of `AbstractSurrogate` need to be callable with input points `x` that
-evaluates the surrogate at `x`.
+Subtypes of `AbstractSurrogate` need to be callable with input points `x` such that the result
+is an evaluation of the surrogate at `x`.
 
  # Examples
  ```jldoctest
@@ -132,7 +132,7 @@ function rand end
 
 Return a sample from the posterior distribution at a point `x`.
 """
-rand(s::AbstractSurrogate{D, R}, x::D) where {D, R}= only(rand(s::AbstractSurrogate, [x]))
+rand(s::AbstractSurrogate{D, R}, x::D) where {D, R} = only(rand(s::AbstractSurrogate, [x]))
 
 """
     logpdf(s::AbstractSurrogate)

--- a/src/SurrogatesBase.jl
+++ b/src/SurrogatesBase.jl
@@ -14,7 +14,7 @@ export AbstractSurrogate,
 An abstract type for surrogates, parametrized by domain type `D` and
 range type `R` of the underlying function that is being approximated.
 
-    (s::AbstractSurrogate{D, R})(x::D) where {D, R}
+    (s::AbstractSurrogate{D})(x::D) where D
 
 Subtypes of `AbstractSurrogate` need to be callable with input points `x` such that the result
 is an evaluation of the surrogate at `x`.
@@ -23,7 +23,7 @@ is an evaluation of the surrogate at `x`.
  ```jldoctest
  julia> struct ZeroSurrogate{D, R} <: AbstractSurrogate{D, R} end
 
- julia> (::ZeroSurrogate{D,R})(x::D) where {D,R} = 0
+ julia> (::ZeroSurrogate{D})(x::D) where D = 0
 
  julia> s = ZeroSurrogate{Int, Int}()
  ZeroSurrogate{Int64, Int64}()
@@ -73,7 +73,7 @@ See also [`update_hyperparameters!`](@ref).
 function hyperparameters end
 
 """
-    posterior(s::AbstractSurrogate{D, R}, xs::AbstractVector{D}) where {D, R}
+    posterior(s::AbstractSurrogate{D}, xs::AbstractVector{D}) where D
 
 Return a joint posterior at points `xs`.
 
@@ -81,58 +81,58 @@ Use `posterior(s, eachslice(X, dims = 2))` if `X` is a matrix.
 """
 function posterior end
 """
-    posterior(s::AbstractSurrogate{D, R}, x::D) where {D, R}
+    posterior(s::AbstractSurrogate{D}, x::D) where D
 
 Return posterior at point `x`.
 """
-posterior(s::AbstractSurrogate{D, R}, x::D) where {D, R} = posterior(s, [x])
+posterior(s::AbstractSurrogate{D}, x::D) where D = posterior(s, [x])
 
 """
-    mean(s::AbstractSurrogate{D, R}, x::D) where {D, R}
+    mean(s::AbstractSurrogate{D}, x::D) where D
 
 Return mean at point `x`.
 """
 function mean end
 """
-    mean(s::AbstractSurrogate{D, R}, xs::AbstractVector{D}) where {D, R}
+    mean(s::AbstractSurrogate{D}, xs::AbstractVector{D}) where D
 
 Return a vector of means at points `xs`.
 
 Use `mean(s, eachslice(X, dims = 2))` if `X` is a matrix.
 """
-function mean(s::AbstractSurrogate{D, R}, xs::AbstractVector{D}) where {D, R}
+function mean(s::AbstractSurrogate{D}, xs::AbstractVector{D}) where D
     mean.(Ref(s), xs)
 end
 
 """
-    var(s::AbstractSurrogate{D, R}, x::D) where {D, R}
+    var(s::AbstractSurrogate{D}, x::D) where D
 
 Return variance at point `x`.
 """
 function var end
 
 """
-    var(s::AbstractSurrogate{D, R}, xs::AbstractVector{D}) where {D, R}
+    var(s::AbstractSurrogate{D}, xs::AbstractVector{D}) where D
 
 Return a vector of variances at points `xs`.
 """
-function var(s::AbstractSurrogate{D, R}, xs::AbstractVector{D}) where {D, R}
+function var(s::AbstractSurrogate{D}, xs::AbstractVector{D}) where D
     var.(Ref(s), xs)
 end
 
 """
-    rand(s::AbstractSurrogate{D, R}, xs::AbstractVector{D}) where {D, R}
+    rand(s::AbstractSurrogate{D}, xs::AbstractVector{D}) where D
 
 Return a sample from the joint posterior at points `xs`.
 """
 function rand end
 
 """
-    rand(s::AbstractSurrogate{D,R}, x::D)
+    rand(s::AbstractSurrogate{D}, x::D) where D
 
 Return a sample from the posterior distribution at a point `x`.
 """
-rand(s::AbstractSurrogate{D, R}, x::D) where {D, R} = only(rand(s::AbstractSurrogate, [x]))
+rand(s::AbstractSurrogate{D}, x::D) where D = only(rand(s::AbstractSurrogate, [x]))
 
 """
     logpdf(s::AbstractSurrogate)

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,0 +1,3 @@
+[deps]
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,12 +8,16 @@ mutable struct DummySurrogate{X, Y} <: AbstractSurrogate
     xs::Vector{X}
     ys::Vector{Y}
 end
+
 # return y value of the closest ξ in xs to x
 (s::DummySurrogate)(x::AbstractVector) = s.ys[argmin(norm(x - ξ) for ξ in s.xs)]
 function add_point!(s::DummySurrogate, new_x, new_y)
     push!(s.xs, new_x)
     push!(s.ys, new_y)
 end
+
+# dummy mean_at_point
+mean_at_point(s::DummySurrogate, x::AbstractVector) = x
 
 mutable struct HyperparameterDummySurrogate{X, Y} <: AbstractSurrogate
     xs::Vector{X}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -25,7 +25,7 @@ end
 function mean(s::DummySurrogate{D}, x::D) where {D <: AbstractVector}
     norm(x)
 end
-# mean for 1D surrogate
+# dummy mean at point for 1D surrogate
 mean(s::DummySurrogate{D}, x::D) where {D <: Number} = x
 # dummy variance at point
 var(s::DummySurrogate{D}, x::D) where {D} = 5

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,7 +7,7 @@ import SurrogatesBase:
 using Test
 using LinearAlgebra
 
-mutable struct DummySurrogate{D, R} <: AbstractSurrogate{D, R}
+struct DummySurrogate{D, R} <: AbstractSurrogate{D, R}
     xs::Vector{D}
     ys::Vector{R}
 end
@@ -20,13 +20,21 @@ function add_point!(s::DummySurrogate{D, R}, new_x::D, new_y::R) where {D, R}
 end
 
 # dummy mean at point
-mean(s::DummySurrogate{D, R}, x::D) where {D, R} = norm(x)
+function mean(s::DummySurrogate{D, R},
+    x::D) where {D <: Union{<:Number, <:AbstractVector}, R}
+    norm(x)
+end
 # dummy variance at point
-var(s::DummySurrogate{D,R}, x::D) where {D, R} = 5
+var(s::DummySurrogate{D, R}, x::D) where {D, R} = 5
 # dummy variance at more points
 var(s::DummySurrogate{D, R}, xs::Vector{D}) where {D, R} = ones(Base.length(xs))
 # dummy logpdf
-logpdf(s::DummySurrogate, x) = 0.5
+logpdf(s::DummySurrogate) = 0.5
+# dummy rand from joint posterior
+function rand(s::AbstractSurrogate{D, R},
+    xs::Vector{D}) where {D <: Union{<:Number, <:Vector}, R <: Union{Float32, Float64}}
+    rand(R, length(xs))
+end
 
 @testset "add_point! with broadcasting implementation" begin
     d = DummySurrogate(Vector{Vector{Float64}}(), Vector{Int}())
@@ -50,8 +58,8 @@ end
     # use DummySurrogate
     d = DummySurrogate(Vector{Vector{Float64}}(), Vector{Int}())
     add_point!(d, [1.9, 2.1], 5)
-    @test isapprox( mean(d, [1.0, 4.0]),  norm([1.0, 4.0]))
-    @test isapprox( mean(d, [[1.0, 4.0], [5.0, 6.0]]) , [norm([1.0, 4.0]), norm([5.0, 6.0])])
+    @test isapprox(mean(d, [1.0, 4.0]), norm([1.0, 4.0]))
+    @test isapprox(mean(d, [[1.0, 4.0], [5.0, 6.0]]), [norm([1.0, 4.0]), norm([5.0, 6.0])])
 end
 
 @testset "logpdf" begin
@@ -60,22 +68,27 @@ end
     @test logpdf(d) == 0.5
 end
 
-@testset "not implemented methods throw an error" begin
+@testset "not implemented methods that are not imported in SurrogatsBase throw an error" begin
     d = DummySurrogate(Vector{Vector{Float64}}(), Vector{Float64}())
     add_point!(d, [1.9, 2.1], 5.9)
     @test_throws MethodError hyperparameters(d)
     @test_throws MethodError update_hyperparameters!(d, 5)
     @test_throws MethodError posterior(d, 5)
-    @test_throws MethodError rand(d, 5)
+end
+
+@testset "rand, test default pointwise implementation" begin
+    d = DummySurrogate(Vector{Vector{Float64}}(), Vector{Float32}())
+    add_point!(d, [1.9, 2.1], 5.9f0)
+    @test length(rand(d, [[1.3, 4.], [5.,6.]])) == 2
+    @test isa(rand(d, [1., 4.]), Float32)
 end
 
 @testset "add_point! in 1D surrogate" begin
     d = DummySurrogate(Vector{Float64}(), Vector{Float64}())
-    add_point!(d, 1, 3)
-    add_point!(d, [2,3,4], [4,5,6])
-    @test length(d.x) == 5
+    add_point!(d, 1., 3.)
+    add_point!(d, [2., 3., 4.], [4., 5., 6.])
+    @test length(d.xs) == 4
 end
-
 
 mutable struct HyperparameterDummySurrogate{D, R} <: AbstractSurrogate{D, R}
     xs::Vector{D}
@@ -96,7 +109,7 @@ end
 
 @testset "hyperparameter interface" begin
     hd = HyperparameterDummySurrogate(Vector{Vector{Float64}}(),
-         Vector{Float64}(),
+        Vector{Float64}(),
         (; p = 2))
     add_point!(hd, [1.9, 2.1], 5.0)
     add_point!(hd, [10.3, 0.1], 9.0)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,73 @@
 using SurrogatesBase
+import SurrogatesBase: add_point!,
+    supports_hyperparameters, update_hyperparameters!, hyperparameters
 using Test
+using LinearAlgebra
 
-@testset "SurrogatesBase.jl" begin
-    # Write your tests here.
+mutable struct DummySurrogate{X, Y} <: AbstractSurrogate
+    xs::Vector{X}
+    ys::Vector{Y}
+end
+# return y value of the closest ξ in xs to x
+(s::DummySurrogate)(x) = s.ys[argmin(norm(x - ξ) for ξ in s.xs)]
+function add_point!(s::DummySurrogate, new_x, new_y)
+    push!(s.xs, new_x)
+    push!(s.ys, new_y)
+end
+
+mutable struct HyperparameterDummySurrogate{X, Y} <: AbstractSurrogate
+    xs::Vector{X}
+    ys::Vector{Y}
+    θ::NamedTuple
+end
+# return y value of the closest ξ in xs to x, in p-norm where p is a hyperparameter
+(s::HyperparameterDummySurrogate)(x) = s.ys[argmin(norm(x - ξ, s.θ.p) for ξ in s.xs)]
+function add_point!(s::DummySurrogate, new_x, new_y)
+    push!(s.xs, new_x)
+    push!(s.ys, new_y)
+end
+supports_hyperparameters(s::HyperparameterDummySurrogate) = true
+hyperparameters(s::HyperparameterDummySurrogate) = s.θ
+function update_hyperparameters!(s::HyperparameterDummySurrogate, prior)
+    # "hyperparmeter optimization"
+    s.θ = (; p = (s.θ.p + prior.p) / 2)
+end
+
+@testset "add_points!" begin
+    # use DummySurrogate
+    d = DummySurrogate(Vector{Vector{Float64}}(), Vector{Int}())
+    add_point!(d, [1.9, 2.1], 5)
+    add_point!(d, [10.3, 0.1], 9)
+    add_points!(d, [[-0.3, 9.9], [-0.1, -10.0]], [1, 3])
+    # check if add_points! added points correctly
+    @test length(d.xs) == 4
+    @test d([0.0, -9.9]) == 3
+end
+
+@testset "default implementations" begin
+    # use DummySurrogate
+    d = DummySurrogate(Vector{Vector{Float64}}(), Vector{Float64}())
+    add_point!(d, [1.9, 2.1], 5.0)
+    add_point!(d, [10.3, 0.1], 9.0)
+
+    @test d([2.0, 2.0]) == 5.0
+    @test !supports_hyperparameters(d)
+    @test_throws ErrorException hyperparameters(d)
+    @test_throws ErrorException update_hyperparameters!(d, 5)
+    @test !supports_posterior(d)
+    @test_throws ErrorException posterior(d, 5)
+end
+
+@testset "hyperparameter interface" begin
+    # use HyperparameterDummySurrogate
+    hd = HyperparameterDummySurrogate(Vector{Vector{Float64}}(),
+        Vector{Float64}(),
+        (; p = 2))
+    add_point!(hd, [1.9, 2.1], 5.0)
+    add_point!(hd, [10.3, 0.1], 9.0)
+
+    @test supports_hyperparameters(hd)
+    @test hyperparameters(hd).p == 2
+    update_hyperparameters!(hd, (; p = 4))
+    @test hyperparameters(hd).p == 3
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,7 +11,7 @@ end
 
 # return y value of the closest ξ in xs to x
 (s::DummySurrogate)(x::AbstractVector) = s.ys[argmin(norm(x - ξ) for ξ in s.xs)]
-function add_point!(s::DummySurrogate, new_x, new_y)
+function add_point!(s::DummySurrogate, new_x::AbstractVector, new_y::Number)
     push!(s.xs, new_x)
     push!(s.ys, new_y)
 end
@@ -26,7 +26,7 @@ mutable struct HyperparameterDummySurrogate{X, Y} <: AbstractSurrogate
 end
 # return y value of the closest ξ in xs to x, in p-norm where p is a hyperparameter
 (s::HyperparameterDummySurrogate)(x) = s.ys[argmin(norm(x - ξ, s.θ.p) for ξ in s.xs)]
-function add_point!(s::HyperparameterDummySurrogate, new_x, new_y)
+function add_point!(s::HyperparameterDummySurrogate, new_x::AbstractVector, new_y::Number)
     push!(s.xs, new_x)
     push!(s.ys, new_y)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,28 +13,33 @@ struct DummySurrogate{D, R} <: AbstractSurrogate{D, R}
 end
 
 # return y value of the closest ξ in xs to x
-(s::DummySurrogate{D, R})(x::D) where {D, R} = s.ys[argmin(norm(x - ξ) for ξ in s.xs)]
+function (s::DummySurrogate{D})(x::T) where {D, T <: Vector}
+    s.ys[argmin(norm(x - ξ) for ξ in s.xs)]
+end
 function add_point!(s::DummySurrogate{D, R}, new_x::D, new_y::R) where {D, R}
     push!(s.xs, new_x)
     push!(s.ys, new_y)
 end
 
 # dummy mean at point
-function mean(s::DummySurrogate{D, R},
-    x::D) where {D <: Union{<:Number, <:AbstractVector}, R}
+function mean(s::DummySurrogate{D},  x::D) where D <: AbstractVector
     norm(x)
 end
+# mean for 1D surrogate
+mean(s::DummySurrogate{<:Number}, x::Number) = x
 # dummy variance at point
-var(s::DummySurrogate{D, R}, x::D) where {D, R} = 5
+var(s::DummySurrogate{D}, x::D) where D = 5
 # dummy variance at more points
-var(s::DummySurrogate{D, R}, xs::Vector{D}) where {D, R} = ones(Base.length(xs))
+var(s::DummySurrogate{D}, xs::Vector{D}) where D = ones(Base.length(xs))
 # dummy logpdf
 logpdf(s::DummySurrogate) = 0.5
 # dummy rand from joint posterior
-function rand(s::AbstractSurrogate{D, R},
+function rand(s::DummySurrogate{D, R},
     xs::Vector{D}) where {D <: Union{<:Number, <:Vector}, R <: Union{Float32, Float64}}
     rand(R, length(xs))
 end
+# dummy joint posterior
+posterior(s::DummySurrogate{D}, x::Vector{D}) where D = ones(Int, length(x))
 
 @testset "add_point! with broadcasting implementation" begin
     d = DummySurrogate(Vector{Vector{Float64}}(), Vector{Int}())
@@ -79,15 +84,25 @@ end
 @testset "rand, test default pointwise implementation" begin
     d = DummySurrogate(Vector{Vector{Float64}}(), Vector{Float32}())
     add_point!(d, [1.9, 2.1], 5.9f0)
-    @test length(rand(d, [[1.3, 4.], [5.,6.]])) == 2
-    @test isa(rand(d, [1., 4.]), Float32)
+    @test length(rand(d, [[1.3, 4.0], [5.0, 6.0]])) == 2
+    @test isa(rand(d, [1.0, 4.0]), Float32)
 end
 
-@testset "add_point! in 1D surrogate" begin
+@testset "1D surrogate" begin
     d = DummySurrogate(Vector{Float64}(), Vector{Float64}())
-    add_point!(d, 1., 3.)
-    add_point!(d, [2., 3., 4.], [4., 5., 6.])
+    add_point!(d, 1.0, 3.0)
+    add_point!(d, [2.0, 3.0, 4.0], [4.0, 5.0, 6.0])
     @test length(d.xs) == 4
+    # 1d mean
+    @test mean(d, 3) == 3
+end
+
+@testset "posterior" begin
+    d = DummySurrogate(Vector{Vector{Float64}}(), Vector{Float32}())
+    add_point!(d, [1.9, 2.1], 5.9f0)
+    @test length( posterior(d, [[1.,3.],[4.,5.]]) ) == 2
+    # test default implementation
+    @test posterior(d, [1.,3.]) == [1]
 end
 
 # mutable b/c of hyperparameters in θ that change

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,8 +1,7 @@
 using SurrogatesBase
-import SurrogatesBase:
-    add_point!,
+import SurrogatesBase: add_point!,
     update_hyperparameters!, hyperparameters,
-    mean, var, rand, mean_and_var
+    mean, var, mean_and_var, rand
 
 using Test
 using LinearAlgebra

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,7 +2,7 @@ using SurrogatesBase
 import SurrogatesBase:
     add_point!,
     update_hyperparameters!, hyperparameters,
-    posterior, mean, var, rand, logpdf
+    posterior, mean, var, rand
 
 using Test
 using LinearAlgebra
@@ -31,8 +31,6 @@ mean(s::DummySurrogate{D}, x::D) where D <: Number = x
 var(s::DummySurrogate{D}, x::D) where D = 5
 # dummy variance at more points
 var(s::DummySurrogate{D}, xs::Vector{D}) where D = ones(Base.length(xs))
-# dummy logpdf
-logpdf(s::DummySurrogate) = 0.5
 # dummy rand from joint posterior
 function rand(s::DummySurrogate{D},
     xs::Vector{D}) where D <: Union{<:Number, <:Vector}
@@ -65,12 +63,6 @@ end
     add_point!(d, [1.9, 2.1], 5)
     @test isapprox(mean(d, [1.0, 4.0]), norm([1.0, 4.0]))
     @test isapprox(mean(d, [[1.0, 4.0], [5.0, 6.0]]), [norm([1.0, 4.0]), norm([5.0, 6.0])])
-end
-
-@testset "logpdf" begin
-    d = DummySurrogate(Vector{Vector{Float64}}(), Vector{Float64}())
-    add_point!(d, [1.9, 2.1], 5.9)
-    @test logpdf(d) == 0.5
 end
 
 @testset "not implemented methods that are not imported in SurrogatsBase throw an error" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,70 +1,72 @@
-using SurrogatesBase
-import SurrogatesBase: add_point!,
-    update_hyperparameters!, hyperparameters
-using Test
-using LinearAlgebra
+# TODO: tests
+#
+# using SurrogatesBase
+# import SurrogatesBase: add_point!,
+#     update_hyperparameters!, hyperparameters
+# using Test
+# using LinearAlgebra
 
-mutable struct DummySurrogate{X, Y} <: AbstractSurrogate
-    xs::Vector{X}
-    ys::Vector{Y}
-end
-# return y value of the closest ξ in xs to x
-(s::DummySurrogate)(x) = s.ys[argmin(norm(x - ξ) for ξ in s.xs)]
-function add_point!(s::DummySurrogate, new_x, new_y)
-    push!(s.xs, new_x)
-    push!(s.ys, new_y)
-end
+# mutable struct DummySurrogate{X, Y} <: AbstractSurrogate
+#     xs::Vector{X}
+#     ys::Vector{Y}
+# end
+# # return y value of the closest ξ in xs to x
+# (s::DummySurrogate)(x) = s.ys[argmin(norm(x - ξ) for ξ in s.xs)]
+# function add_point!(s::DummySurrogate, new_x, new_y)
+#     push!(s.xs, new_x)
+#     push!(s.ys, new_y)
+# end
 
-mutable struct HyperparameterDummySurrogate{X, Y} <: AbstractSurrogate
-    xs::Vector{X}
-    ys::Vector{Y}
-    θ::NamedTuple
-end
-# return y value of the closest ξ in xs to x, in p-norm where p is a hyperparameter
-(s::HyperparameterDummySurrogate)(x) = s.ys[argmin(norm(x - ξ, s.θ.p) for ξ in s.xs)]
-function add_point!(s::DummySurrogate, new_x, new_y)
-    push!(s.xs, new_x)
-    push!(s.ys, new_y)
-end
-supports_hyperparameters(s::HyperparameterDummySurrogate) = true
-hyperparameters(s::HyperparameterDummySurrogate) = s.θ
-function update_hyperparameters!(s::HyperparameterDummySurrogate, prior)
-    # "hyperparmeter optimization"
-    s.θ = (; p = (s.θ.p + prior.p) / 2)
-end
+# mutable struct HyperparameterDummySurrogate{X, Y} <: AbstractSurrogate
+#     xs::Vector{X}
+#     ys::Vector{Y}
+#     θ::NamedTuple
+# end
+# # return y value of the closest ξ in xs to x, in p-norm where p is a hyperparameter
+# (s::HyperparameterDummySurrogate)(x) = s.ys[argmin(norm(x - ξ, s.θ.p) for ξ in s.xs)]
+# function add_point!(s::DummySurrogate, new_x, new_y)
+#     push!(s.xs, new_x)
+#     push!(s.ys, new_y)
+# end
+# supports_hyperparameters(s::HyperparameterDummySurrogate) = true
+# hyperparameters(s::HyperparameterDummySurrogate) = s.θ
+# function update_hyperparameters!(s::HyperparameterDummySurrogate, prior)
+#     # "hyperparmeter optimization"
+#     s.θ = (; p = (s.θ.p + prior.p) / 2)
+# end
 
-@testset "add_points!" begin
-    # use DummySurrogate
-    d = DummySurrogate(Vector{Vector{Float64}}(), Vector{Int}())
-    add_point!(d, [1.9, 2.1], 5)
-    add_point!(d, [10.3, 0.1], 9)
-    add_points!(d, [[-0.3, 9.9], [-0.1, -10.0]], [1, 3])
-    # check if add_points! added points correctly
-    @test length(d.xs) == 4
-    @test d([0.0, -9.9]) == 3
-end
+# @testset "add_points!" begin
+#     # use DummySurrogate
+#     d = DummySurrogate(Vector{Vector{Float64}}(), Vector{Int}())
+#     add_point!(d, [1.9, 2.1], 5)
+#     add_point!(d, [10.3, 0.1], 9)
+#     add_points!(d, [[-0.3, 9.9], [-0.1, -10.0]], [1, 3])
+#     # check if add_points! added points correctly
+#     @test length(d.xs) == 4
+#     @test d([0.0, -9.9]) == 3
+# end
 
-@testset "default implementations" begin
-    # use DummySurrogate
-    d = DummySurrogate(Vector{Vector{Float64}}(), Vector{Float64}())
-    add_point!(d, [1.9, 2.1], 5.0)
-    add_point!(d, [10.3, 0.1], 9.0)
+# @testset "default implementations" begin
+#     # use DummySurrogate
+#     d = DummySurrogate(Vector{Vector{Float64}}(), Vector{Float64}())
+#     add_point!(d, [1.9, 2.1], 5.0)
+#     add_point!(d, [10.3, 0.1], 9.0)
 
-    @test d([2.0, 2.0]) == 5.0
-    @test_throws ErrorException hyperparameters(d)
-    @test_throws ErrorException update_hyperparameters!(d, 5)
-    @test_throws ErrorException posterior(d, 5)
-end
+#     @test d([2.0, 2.0]) == 5.0
+#     @test_throws ErrorException hyperparameters(d)
+#     @test_throws ErrorException update_hyperparameters!(d, 5)
+#     @test_throws ErrorException posterior(d, 5)
+# end
 
-@testset "hyperparameter interface" begin
-    # use HyperparameterDummySurrogate
-    hd = HyperparameterDummySurrogate(Vector{Vector{Float64}}(),
-        Vector{Float64}(),
-        (; p = 2))
-    add_point!(hd, [1.9, 2.1], 5.0)
-    add_point!(hd, [10.3, 0.1], 9.0)
+# @testset "hyperparameter interface" begin
+#     # use HyperparameterDummySurrogate
+#     hd = HyperparameterDummySurrogate(Vector{Vector{Float64}}(),
+#         Vector{Float64}(),
+#         (; p = 2))
+#     add_point!(hd, [1.9, 2.1], 5.0)
+#     add_point!(hd, [10.3, 0.1], 9.0)
 
-    @test hyperparameters(hd).p == 2
-    update_hyperparameters!(hd, (; p = 4))
-    @test hyperparameters(hd).p == 3
-end
+#     @test hyperparameters(hd).p == 2
+#     update_hyperparameters!(hd, (; p = 4))
+#     @test hyperparameters(hd).p == 3
+# end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,7 +13,7 @@ struct DummySurrogate{D, R} <: AbstractSurrogate{D, R}
 end
 
 # return y value of the closest ξ in xs to x
-function (s::DummySurrogate{D})(x::D) where D <: Vector
+function (s::DummySurrogate{D})(x::D) where {D <: Vector}
     s.ys[argmin(norm(x - ξ) for ξ in s.xs)]
 end
 function add_point!(s::DummySurrogate{D, R}, new_x::D, new_y::R) where {D, R}
@@ -22,22 +22,22 @@ function add_point!(s::DummySurrogate{D, R}, new_x::D, new_y::R) where {D, R}
 end
 
 # dummy mean at point
-function mean(s::DummySurrogate{D},  x::D) where D <: AbstractVector
+function mean(s::DummySurrogate{D}, x::D) where {D <: AbstractVector}
     norm(x)
 end
 # mean for 1D surrogate
-mean(s::DummySurrogate{D}, x::D) where D <: Number = x
+mean(s::DummySurrogate{D}, x::D) where {D <: Number} = x
 # dummy variance at point
-var(s::DummySurrogate{D}, x::D) where D = 5
+var(s::DummySurrogate{D}, x::D) where {D} = 5
 # dummy variance at more points
-var(s::DummySurrogate{D}, xs::Vector{D}) where D = ones(Base.length(xs))
+var(s::DummySurrogate{D}, xs::Vector{D}) where {D} = ones(Base.length(xs))
 # dummy rand from joint posterior
 function rand(s::DummySurrogate{D},
-    xs::Vector{D}) where D <: Union{<:Number, <:Vector}
+    xs::Vector{D}) where {D <: Union{<:Number, <:Vector}}
     rand(length(xs))
 end
 # dummy joint posterior
-posterior(s::DummySurrogate{D}, x::Vector{D}) where D = ones(Int, length(x))
+posterior(s::DummySurrogate{D}, x::Vector{D}) where {D} = ones(Int, length(x))
 
 @testset "add_point! with broadcasting implementation" begin
     d = DummySurrogate(Vector{Vector{Float64}}(), Vector{Int}())
@@ -85,15 +85,15 @@ end
     add_point!(d, [2.0, 3.0, 4.0], [4.0, 5.0, 6.0])
     @test length(d.xs) == 4
     # 1d mean
-    @test mean(d, 3.) == 3
+    @test mean(d, 3.0) == 3
 end
 
 @testset "posterior" begin
     d = DummySurrogate(Vector{Vector{Float64}}(), Vector{Float32}())
     add_point!(d, [1.9, 2.1], 5.9f0)
-    @test length( posterior(d, [[1.,3.],[4.,5.]]) ) == 2
+    @test length(posterior(d, [[1.0, 3.0], [4.0, 5.0]])) == 2
     # test default implementation
-    @test posterior(d, [1.,3.]) == [1]
+    @test posterior(d, [1.0, 3.0]) == [1]
 end
 
 # mutable b/c of hyperparameters in θ that change
@@ -103,7 +103,9 @@ mutable struct HyperparameterDummySurrogate{D, R} <: AbstractSurrogate{D, R}
     θ::NamedTuple
 end
 # return y value of the closest ξ in xs to x, in p-norm where p is a hyperparameter
-(s::HyperparameterDummySurrogate{D})(x::D) where D <: Vector = s.ys[argmin(norm(x - ξ, s.θ.p) for ξ in s.xs)]
+function (s::HyperparameterDummySurrogate{D})(x::D) where {D <: Vector}
+    s.ys[argmin(norm(x - ξ, s.θ.p) for ξ in s.xs)]
+end
 function add_point!(s::HyperparameterDummySurrogate{D, R}, new_x::D, new_y::R) where {D, R}
     push!(s.xs, new_x)
     push!(s.ys, new_y)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,48 +1,34 @@
 using SurrogatesBase
-import SurrogatesBase: add_point!,
-    update_hyperparameters!, hyperparameters, mean, var
+import SurrogatesBase:
+    add_point!,
+    update_hyperparameters!, hyperparameters,
+    posterior, mean, var, rand, logpdf
+
 using Test
 using LinearAlgebra
 
-mutable struct DummySurrogate{X, Y} <: AbstractSurrogate
-    xs::Vector{X}
-    ys::Vector{Y}
+mutable struct DummySurrogate{D, R} <: AbstractSurrogate{D, R}
+    xs::Vector{D}
+    ys::Vector{R}
 end
 
 # return y value of the closest ξ in xs to x
-(s::DummySurrogate)(x::AbstractVector) = s.ys[argmin(norm(x - ξ) for ξ in s.xs)]
-function add_point!(s::DummySurrogate, new_x::AbstractVector, new_y::Number)
+(s::DummySurrogate{D, R})(x::D) where {D, R} = s.ys[argmin(norm(x - ξ) for ξ in s.xs)]
+function add_point!(s::DummySurrogate{D, R}, new_x::D, new_y::R) where {D, R}
     push!(s.xs, new_x)
     push!(s.ys, new_y)
 end
 
 # dummy mean at point
-mean(s::DummySurrogate, x::AbstractVector{<:Number}) = x
+mean(s::DummySurrogate{D, R}, x::D) where {D, R} = norm(x)
+# dummy variance at point
+var(s::DummySurrogate{D,R}, x::D) where {D, R} = 5
 # dummy variance at more points
-var(s::DummySurrogate, xs::AbstractVector{AbstractVector{<:Number}}) = (x -> x^2).(xs)
-
-mutable struct HyperparameterDummySurrogate{X, Y} <: AbstractSurrogate
-    xs::Vector{X}
-    ys::Vector{Y}
-    θ::NamedTuple
-end
-
-# return y value of the closest ξ in xs to x, in p-norm where p is a hyperparameter
-(s::HyperparameterDummySurrogate)(x) = s.ys[argmin(norm(x - ξ, s.θ.p) for ξ in s.xs)]
-function add_point!(s::HyperparameterDummySurrogate, new_x::AbstractVector, new_y::Number)
-    push!(s.xs, new_x)
-    push!(s.ys, new_y)
-end
-supports_hyperparameters(s::HyperparameterDummySurrogate) = true
-hyperparameters(s::HyperparameterDummySurrogate) = s.θ
-function update_hyperparameters!(s::HyperparameterDummySurrogate, prior)
-    # "hyperparmeter optimization"
-    s.θ = (; p = (s.θ.p + prior.p) / 2)
-end
-
+var(s::DummySurrogate{D, R}, xs::Vector{D}) where {D, R} = ones(Base.length(xs))
+# dummy logpdf
+logpdf(s::DummySurrogate, x) = 0.5
 
 @testset "add_point! with broadcasting implementation" begin
-    # use DummySurrogate
     d = DummySurrogate(Vector{Vector{Float64}}(), Vector{Int}())
     add_point!(d, [1.9, 2.1], 5)
     add_point!(d, [10.3, 0.1], 9)
@@ -52,29 +38,65 @@ end
     @test d([0.0, -9.9]) == 3
 end
 
-@testset "mean with broadcasting" begin
-      # use DummySurrogate
+@testset "var" begin
+    # use DummySurrogate
     d = DummySurrogate(Vector{Vector{Float64}}(), Vector{Int}())
     add_point!(d, [1.9, 2.1], 5)
-    @test mean(d, [[1., 4. ], [5.,6.]]) == [[1., 4. ], [5.,6.]]
+    @test var(d, [1.0, 4.0]) == 5
+    @test var(d, [[1.0, 4.0], [5.0, 6.0]]) == ones(2)
 end
 
-@testset "default implementations" begin
+@testset "mean" begin
     # use DummySurrogate
-    d = DummySurrogate(Vector{Vector{Float64}}(), Vector{Float64}())
-    add_point!(d, [1.9, 2.1], 5.0)
-    add_point!(d, [10.3, 0.1], 9.0)
+    d = DummySurrogate(Vector{Vector{Float64}}(), Vector{Int}())
+    add_point!(d, [1.9, 2.1], 5)
+    @test isapprox( mean(d, [1.0, 4.0]),  norm([1.0, 4.0]))
+    @test isapprox( mean(d, [[1.0, 4.0], [5.0, 6.0]]) , [norm([1.0, 4.0]), norm([5.0, 6.0])])
+end
 
-    @test d([2.0, 2.0]) == 5.0
+@testset "logpdf" begin
+    d = DummySurrogate(Vector{Vector{Float64}}(), Vector{Float64}())
+    add_point!(d, [1.9, 2.1], 5.9)
+    @test logpdf(d) == 0.5
+end
+
+@testset "not implemented methods throw an error" begin
+    d = DummySurrogate(Vector{Vector{Float64}}(), Vector{Float64}())
+    add_point!(d, [1.9, 2.1], 5.9)
     @test_throws MethodError hyperparameters(d)
     @test_throws MethodError update_hyperparameters!(d, 5)
     @test_throws MethodError posterior(d, 5)
+    @test_throws MethodError rand(d, 5)
+end
+
+@testset "add_point! in 1D surrogate" begin
+    d = DummySurrogate(Vector{Float64}(), Vector{Float64}())
+    add_point!(d, 1, 3)
+    add_point!(d, [2,3,4], [4,5,6])
+    @test length(d.x) == 5
+end
+
+
+mutable struct HyperparameterDummySurrogate{D, R} <: AbstractSurrogate{D, R}
+    xs::Vector{D}
+    ys::Vector{R}
+    θ::NamedTuple
+end
+# return y value of the closest ξ in xs to x, in p-norm where p is a hyperparameter
+(s::HyperparameterDummySurrogate)(x) = s.ys[argmin(norm(x - ξ, s.θ.p) for ξ in s.xs)]
+function add_point!(s::HyperparameterDummySurrogate{D, R}, new_x::D, new_y::R) where {D, R}
+    push!(s.xs, new_x)
+    push!(s.ys, new_y)
+end
+hyperparameters(s::HyperparameterDummySurrogate) = s.θ
+function update_hyperparameters!(s::HyperparameterDummySurrogate, prior)
+    # "hyperparmeter optimization"
+    s.θ = (; p = (s.θ.p + prior.p) / 2)
 end
 
 @testset "hyperparameter interface" begin
-    # use HyperparameterDummySurrogate
     hd = HyperparameterDummySurrogate(Vector{Vector{Float64}}(),
-        Vector{Float64}(),
+         Vector{Float64}(),
         (; p = 2))
     add_point!(hd, [1.9, 2.1], 5.0)
     add_point!(hd, [10.3, 0.1], 9.0)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,6 @@
 using SurrogatesBase
 import SurrogatesBase: add_point!,
-    supports_hyperparameters, update_hyperparameters!, hyperparameters
+    update_hyperparameters!, hyperparameters
 using Test
 using LinearAlgebra
 
@@ -51,10 +51,8 @@ end
     add_point!(d, [10.3, 0.1], 9.0)
 
     @test d([2.0, 2.0]) == 5.0
-    @test !supports_hyperparameters(d)
     @test_throws ErrorException hyperparameters(d)
     @test_throws ErrorException update_hyperparameters!(d, 5)
-    @test !supports_posterior(d)
     @test_throws ErrorException posterior(d, 5)
 end
 
@@ -66,7 +64,6 @@ end
     add_point!(hd, [1.9, 2.1], 5.0)
     add_point!(hd, [10.3, 0.1], 9.0)
 
-    @test supports_hyperparameters(hd)
     @test hyperparameters(hd).p == 2
     update_hyperparameters!(hd, (; p = 4))
     @test hyperparameters(hd).p == 3

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,7 +13,7 @@ struct DummySurrogate{D, R} <: AbstractSurrogate{D, R}
 end
 
 # return y value of the closest ξ in xs to x
-function (s::DummySurrogate{D})(x::T) where {D, T <: Vector}
+function (s::DummySurrogate)(x::Vector)
     s.ys[argmin(norm(x - ξ) for ξ in s.xs)]
 end
 function add_point!(s::DummySurrogate{D, R}, new_x::D, new_y::R) where {D, R}
@@ -112,7 +112,7 @@ mutable struct HyperparameterDummySurrogate{D, R} <: AbstractSurrogate{D, R}
     θ::NamedTuple
 end
 # return y value of the closest ξ in xs to x, in p-norm where p is a hyperparameter
-(s::HyperparameterDummySurrogate)(x) = s.ys[argmin(norm(x - ξ, s.θ.p) for ξ in s.xs)]
+(s::HyperparameterDummySurrogate)(x::Vector) = s.ys[argmin(norm(x - ξ, s.θ.p) for ξ in s.xs)]
 function add_point!(s::HyperparameterDummySurrogate{D, R}, new_x::D, new_y::R) where {D, R}
     push!(s.xs, new_x)
     push!(s.ys, new_y)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,6 @@
 using SurrogatesBase
 import SurrogatesBase: add_point!,
-    update_hyperparameters!, hyperparameters
+    update_hyperparameters!, hyperparameters, mean
 using Test
 using LinearAlgebra
 
@@ -16,8 +16,8 @@ function add_point!(s::DummySurrogate, new_x, new_y)
     push!(s.ys, new_y)
 end
 
-# dummy mean_at_point
-mean_at_point(s::DummySurrogate, x::AbstractVector) = x
+# dummy mean at point
+mean(s::DummySurrogate, x::AbstractVector) = x
 
 mutable struct HyperparameterDummySurrogate{X, Y} <: AbstractSurrogate
     xs::Vector{X}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,6 @@
 using SurrogatesBase
 import SurrogatesBase: add_point!,
-    update_hyperparameters!, hyperparameters, mean
+    update_hyperparameters!, hyperparameters, mean, var
 using Test
 using LinearAlgebra
 
@@ -17,13 +17,16 @@ function add_point!(s::DummySurrogate, new_x::AbstractVector, new_y::Number)
 end
 
 # dummy mean at point
-mean(s::DummySurrogate, x::AbstractVector) = x
+mean(s::DummySurrogate, x::AbstractVector{<:Number}) = x
+# dummy variance at more points
+var(s::DummySurrogate, xs::AbstractVector{AbstractVector{<:Number}}) = (x -> x^2).(xs)
 
 mutable struct HyperparameterDummySurrogate{X, Y} <: AbstractSurrogate
     xs::Vector{X}
     ys::Vector{Y}
     θ::NamedTuple
 end
+
 # return y value of the closest ξ in xs to x, in p-norm where p is a hyperparameter
 (s::HyperparameterDummySurrogate)(x) = s.ys[argmin(norm(x - ξ, s.θ.p) for ξ in s.xs)]
 function add_point!(s::HyperparameterDummySurrogate, new_x::AbstractVector, new_y::Number)
@@ -63,9 +66,9 @@ end
     add_point!(d, [10.3, 0.1], 9.0)
 
     @test d([2.0, 2.0]) == 5.0
-    @test_throws ErrorException hyperparameters(d)
-    @test_throws ErrorException update_hyperparameters!(d, 5)
-    @test_throws ErrorException posterior(d, 5)
+    @test_throws MethodError hyperparameters(d)
+    @test_throws MethodError update_hyperparameters!(d, 5)
+    @test_throws MethodError posterior(d, 5)
 end
 
 @testset "hyperparameter interface" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,0 +1,6 @@
+using SurrogatesBase
+using Test
+
+@testset "SurrogatesBase.jl" begin
+    # Write your tests here.
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -90,6 +90,7 @@ end
     @test length(d.xs) == 4
 end
 
+# mutable b/c of hyperparameters in θ that change
 mutable struct HyperparameterDummySurrogate{D, R} <: AbstractSurrogate{D, R}
     xs::Vector{D}
     ys::Vector{R}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,7 +13,7 @@ struct DummySurrogate{D, R} <: AbstractSurrogate{D, R}
 end
 
 # return y value of the closest ξ in xs to x
-function (s::DummySurrogate)(x::Vector)
+function (s::DummySurrogate{D})(x::D) where D <: Vector
     s.ys[argmin(norm(x - ξ) for ξ in s.xs)]
 end
 function add_point!(s::DummySurrogate{D, R}, new_x::D, new_y::R) where {D, R}
@@ -26,7 +26,7 @@ function mean(s::DummySurrogate{D},  x::D) where D <: AbstractVector
     norm(x)
 end
 # mean for 1D surrogate
-mean(s::DummySurrogate{<:Number}, x::Number) = x
+mean(s::DummySurrogate{D}, x::D) where D <: Number = x
 # dummy variance at point
 var(s::DummySurrogate{D}, x::D) where D = 5
 # dummy variance at more points
@@ -34,9 +34,9 @@ var(s::DummySurrogate{D}, xs::Vector{D}) where D = ones(Base.length(xs))
 # dummy logpdf
 logpdf(s::DummySurrogate) = 0.5
 # dummy rand from joint posterior
-function rand(s::DummySurrogate{D, R},
-    xs::Vector{D}) where {D <: Union{<:Number, <:Vector}, R <: Union{Float32, Float64}}
-    rand(R, length(xs))
+function rand(s::DummySurrogate{D},
+    xs::Vector{D}) where D <: Union{<:Number, <:Vector}
+    rand(length(xs))
 end
 # dummy joint posterior
 posterior(s::DummySurrogate{D}, x::Vector{D}) where D = ones(Int, length(x))
@@ -85,7 +85,6 @@ end
     d = DummySurrogate(Vector{Vector{Float64}}(), Vector{Float32}())
     add_point!(d, [1.9, 2.1], 5.9f0)
     @test length(rand(d, [[1.3, 4.0], [5.0, 6.0]])) == 2
-    @test isa(rand(d, [1.0, 4.0]), Float32)
 end
 
 @testset "1D surrogate" begin
@@ -94,7 +93,7 @@ end
     add_point!(d, [2.0, 3.0, 4.0], [4.0, 5.0, 6.0])
     @test length(d.xs) == 4
     # 1d mean
-    @test mean(d, 3) == 3
+    @test mean(d, 3.) == 3
 end
 
 @testset "posterior" begin
@@ -112,7 +111,7 @@ mutable struct HyperparameterDummySurrogate{D, R} <: AbstractSurrogate{D, R}
     θ::NamedTuple
 end
 # return y value of the closest ξ in xs to x, in p-norm where p is a hyperparameter
-(s::HyperparameterDummySurrogate)(x::Vector) = s.ys[argmin(norm(x - ξ, s.θ.p) for ξ in s.xs)]
+(s::HyperparameterDummySurrogate{D})(x::D) where D <: Vector = s.ys[argmin(norm(x - ξ, s.θ.p) for ξ in s.xs)]
 function add_point!(s::HyperparameterDummySurrogate{D, R}, new_x::D, new_y::R) where {D, R}
     push!(s.xs, new_x)
     push!(s.ys, new_y)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,72 +1,78 @@
-# TODO: tests
-#
-# using SurrogatesBase
-# import SurrogatesBase: add_point!,
-#     update_hyperparameters!, hyperparameters
-# using Test
-# using LinearAlgebra
+using SurrogatesBase
+import SurrogatesBase: add_point!,
+    update_hyperparameters!, hyperparameters
+using Test
+using LinearAlgebra
 
-# mutable struct DummySurrogate{X, Y} <: AbstractSurrogate
-#     xs::Vector{X}
-#     ys::Vector{Y}
-# end
-# # return y value of the closest ξ in xs to x
-# (s::DummySurrogate)(x) = s.ys[argmin(norm(x - ξ) for ξ in s.xs)]
-# function add_point!(s::DummySurrogate, new_x, new_y)
-#     push!(s.xs, new_x)
-#     push!(s.ys, new_y)
-# end
+mutable struct DummySurrogate{X, Y} <: AbstractSurrogate
+    xs::Vector{X}
+    ys::Vector{Y}
+end
+# return y value of the closest ξ in xs to x
+(s::DummySurrogate)(x::AbstractVector) = s.ys[argmin(norm(x - ξ) for ξ in s.xs)]
+function add_point!(s::DummySurrogate, new_x, new_y)
+    push!(s.xs, new_x)
+    push!(s.ys, new_y)
+end
 
-# mutable struct HyperparameterDummySurrogate{X, Y} <: AbstractSurrogate
-#     xs::Vector{X}
-#     ys::Vector{Y}
-#     θ::NamedTuple
-# end
-# # return y value of the closest ξ in xs to x, in p-norm where p is a hyperparameter
-# (s::HyperparameterDummySurrogate)(x) = s.ys[argmin(norm(x - ξ, s.θ.p) for ξ in s.xs)]
-# function add_point!(s::DummySurrogate, new_x, new_y)
-#     push!(s.xs, new_x)
-#     push!(s.ys, new_y)
-# end
-# supports_hyperparameters(s::HyperparameterDummySurrogate) = true
-# hyperparameters(s::HyperparameterDummySurrogate) = s.θ
-# function update_hyperparameters!(s::HyperparameterDummySurrogate, prior)
-#     # "hyperparmeter optimization"
-#     s.θ = (; p = (s.θ.p + prior.p) / 2)
-# end
+mutable struct HyperparameterDummySurrogate{X, Y} <: AbstractSurrogate
+    xs::Vector{X}
+    ys::Vector{Y}
+    θ::NamedTuple
+end
+# return y value of the closest ξ in xs to x, in p-norm where p is a hyperparameter
+(s::HyperparameterDummySurrogate)(x) = s.ys[argmin(norm(x - ξ, s.θ.p) for ξ in s.xs)]
+function add_point!(s::HyperparameterDummySurrogate, new_x, new_y)
+    push!(s.xs, new_x)
+    push!(s.ys, new_y)
+end
+supports_hyperparameters(s::HyperparameterDummySurrogate) = true
+hyperparameters(s::HyperparameterDummySurrogate) = s.θ
+function update_hyperparameters!(s::HyperparameterDummySurrogate, prior)
+    # "hyperparmeter optimization"
+    s.θ = (; p = (s.θ.p + prior.p) / 2)
+end
 
-# @testset "add_points!" begin
-#     # use DummySurrogate
-#     d = DummySurrogate(Vector{Vector{Float64}}(), Vector{Int}())
-#     add_point!(d, [1.9, 2.1], 5)
-#     add_point!(d, [10.3, 0.1], 9)
-#     add_points!(d, [[-0.3, 9.9], [-0.1, -10.0]], [1, 3])
-#     # check if add_points! added points correctly
-#     @test length(d.xs) == 4
-#     @test d([0.0, -9.9]) == 3
-# end
 
-# @testset "default implementations" begin
-#     # use DummySurrogate
-#     d = DummySurrogate(Vector{Vector{Float64}}(), Vector{Float64}())
-#     add_point!(d, [1.9, 2.1], 5.0)
-#     add_point!(d, [10.3, 0.1], 9.0)
+@testset "add_point! with broadcasting implementation" begin
+    # use DummySurrogate
+    d = DummySurrogate(Vector{Vector{Float64}}(), Vector{Int}())
+    add_point!(d, [1.9, 2.1], 5)
+    add_point!(d, [10.3, 0.1], 9)
+    add_point!(d, [[-0.3, 9.9], [-0.1, -10.0]], [1, 3])
+    # check if add_points! added points correctly
+    @test length(d.xs) == 4
+    @test d([0.0, -9.9]) == 3
+end
 
-#     @test d([2.0, 2.0]) == 5.0
-#     @test_throws ErrorException hyperparameters(d)
-#     @test_throws ErrorException update_hyperparameters!(d, 5)
-#     @test_throws ErrorException posterior(d, 5)
-# end
+@testset "mean with broadcasting" begin
+      # use DummySurrogate
+    d = DummySurrogate(Vector{Vector{Float64}}(), Vector{Int}())
+    add_point!(d, [1.9, 2.1], 5)
+    @test mean(d, [[1., 4. ], [5.,6.]]) == [[1., 4. ], [5.,6.]]
+end
 
-# @testset "hyperparameter interface" begin
-#     # use HyperparameterDummySurrogate
-#     hd = HyperparameterDummySurrogate(Vector{Vector{Float64}}(),
-#         Vector{Float64}(),
-#         (; p = 2))
-#     add_point!(hd, [1.9, 2.1], 5.0)
-#     add_point!(hd, [10.3, 0.1], 9.0)
+@testset "default implementations" begin
+    # use DummySurrogate
+    d = DummySurrogate(Vector{Vector{Float64}}(), Vector{Float64}())
+    add_point!(d, [1.9, 2.1], 5.0)
+    add_point!(d, [10.3, 0.1], 9.0)
 
-#     @test hyperparameters(hd).p == 2
-#     update_hyperparameters!(hd, (; p = 4))
-#     @test hyperparameters(hd).p == 3
-# end
+    @test d([2.0, 2.0]) == 5.0
+    @test_throws ErrorException hyperparameters(d)
+    @test_throws ErrorException update_hyperparameters!(d, 5)
+    @test_throws ErrorException posterior(d, 5)
+end
+
+@testset "hyperparameter interface" begin
+    # use HyperparameterDummySurrogate
+    hd = HyperparameterDummySurrogate(Vector{Vector{Float64}}(),
+        Vector{Float64}(),
+        (; p = 2))
+    add_point!(hd, [1.9, 2.1], 5.0)
+    add_point!(hd, [10.3, 0.1], 9.0)
+
+    @test hyperparameters(hd).p == 2
+    update_hyperparameters!(hd, (; p = 4))
+    @test hyperparameters(hd).p == 3
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -88,7 +88,7 @@ end
 @testset "default mean_and_var, 1-dimensional surrogate" begin
     d = DummySurrogate(Vector{Float64}(), Vector{Float64}())
     add_point!(d, 1.0, 3.0)
-    μ, σ² = mean_and_var(d, 4.)
+    μ, σ² = mean_and_var(d, 4.0)
     @test isa(μ, Number)
     @test isa(σ², Number)
 
@@ -102,11 +102,11 @@ end
 @testset "default mean_and_var, 2-dimensional surrogate" begin
     d = DummySurrogate(Vector{Vector{Float64}}(), Vector{Float32}())
     add_point!(d, [1.9, 2.1], 5.9f0)
-    μ, σ² = mean_and_var(d,  [1.5, 2.5])
+    μ, σ² = mean_and_var(d, [1.5, 2.5])
     @test isa(μ, Number)
     @test isa(σ², Number)
 
-    μs, σ²s = mean_and_var(d, [ [1.5, 2.5], [5.,6.]])
+    μs, σ²s = mean_and_var(d, [[1.5, 2.5], [5.0, 6.0]])
     @test isa(μs, Vector{<:Number})
     @test isa(σ²s, Vector{<:Number})
     @test length(μs) == 2


### PR DESCRIPTION
Hi!

Johanni Brea (@jbrea) and myself are proposing to extend AbstractSurrogate interface to cover the case of stochastic surrogates, e.g., Gaussian processes. The following code describes a minimal set of surrogate-related generic function definitions, some of them with a default implementation.

We are happy to discuss any comments & improvements, thanks!