### PR TITLE
Add JET.jl static analysis tests

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "1.1.0"
 
 [compat]
 Aqua = "0.8"
+JET = "0.9"
 LinearAlgebra = "1.10"
 SafeTestsets = "0.1"
 Statistics = "1.10"
@@ -13,10 +14,11 @@ julia = "1.10"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "LinearAlgebra", "SafeTestsets", "Statistics", "Test"]
+test = ["Aqua", "JET", "LinearAlgebra", "SafeTestsets", "Statistics", "Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -5,7 +5,7 @@ version = "1.1.0"
 
 [compat]
 Aqua = "0.8"
-JET = "0.9"
+JET = "0.9, 0.10, 0.11"
 LinearAlgebra = "1.10"
 SafeTestsets = "0.1"
 Statistics = "1.10"

--- a/test/jet.jl
+++ b/test/jet.jl
@@ -1,0 +1,78 @@
+using SurrogatesBase
+using JET
+using LinearAlgebra
+import Statistics
+
+@testset "JET static analysis" begin
+    @testset "Package analysis" begin
+        result = JET.report_package("SurrogatesBase")
+        @test length(JET.get_reports(result)) == 0
+    end
+
+    @testset "DummySurrogate type stability" begin
+        # Test implementation from runtests.jl
+        struct JETDummySurrogate{X, Y} <: AbstractDeterministicSurrogate
+            xs::Vector{X}
+            ys::Vector{Y}
+        end
+        (s::JETDummySurrogate)(x) = s.ys[argmin(norm(x - ξ) for ξ in s.xs)]
+        function SurrogatesBase.update!(s::JETDummySurrogate, new_xs, new_ys)
+            append!(s.xs, new_xs)
+            append!(s.ys, new_ys)
+        end
+
+        d = JETDummySurrogate(Vector{Vector{Float64}}(), Vector{Int}())
+        SurrogatesBase.update!(d, [[10.3, 0.1], [1.9, 2.1]], [5, 6])
+
+        # Test call method
+        result = JET.report_call(d, Tuple{Vector{Float64}})
+        @test length(JET.get_reports(result)) == 0
+
+        # Test update! method
+        result = JET.report_call(
+            SurrogatesBase.update!,
+            Tuple{JETDummySurrogate{Vector{Float64}, Int}, Vector{Vector{Float64}},
+                Vector{Int}})
+        @test length(JET.get_reports(result)) == 0
+    end
+
+    @testset "Stochastic surrogate type stability" begin
+        mutable struct JETDummyStochasticSurrogate{X, Y} <: AbstractStochasticSurrogate
+            xs::Vector{X}
+            ys::Vector{Y}
+            ys_mean::Y
+        end
+        function SurrogatesBase.update!(s::JETDummyStochasticSurrogate, new_xs, new_ys)
+            append!(s.xs, new_xs)
+            append!(s.ys, new_ys)
+            s.ys_mean = (s.ys_mean * (length(s.xs) - length(new_xs)) + sum(new_ys)) /
+                        length(s.xs)
+        end
+        SurrogatesBase.parameters(s::JETDummyStochasticSurrogate) = s.ys_mean
+
+        struct JETFiniteDummyStochasticSurrogate{X}
+            means::Vector{X}
+        end
+        Statistics.mean(s::JETFiniteDummyStochasticSurrogate) = s.means
+        function JETFiniteDummyStochasticSurrogate(s, xs)
+            return JETFiniteDummyStochasticSurrogate(s.ys_mean .* ones(length(xs)))
+        end
+        function SurrogatesBase.finite_posterior(s::JETDummyStochasticSurrogate, xs)
+            JETFiniteDummyStochasticSurrogate(s, xs)
+        end
+
+        # Test update! method
+        result = JET.report_call(
+            SurrogatesBase.update!,
+            Tuple{JETDummyStochasticSurrogate{Vector{Float64}, Float64},
+                Vector{Vector{Float64}}, Vector{Float64}})
+        @test length(JET.get_reports(result)) == 0
+
+        # Test finite_posterior
+        result = JET.report_call(
+            SurrogatesBase.finite_posterior,
+            Tuple{JETDummyStochasticSurrogate{Vector{Float64}, Float64},
+                Vector{Vector{Float64}}})
+        @test length(JET.get_reports(result)) == 0
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,7 @@ using SurrogatesBase
 using Test
 using SafeTestsets
 @safetestset "Quality Assurance" include("qa.jl")
+@safetestset "JET Static Analysis" include("jet.jl")
 
 using LinearAlgebra
 import Statistics


### PR DESCRIPTION
## Summary

- Added JET.jl as a test dependency for static analysis
- Created `test/jet.jl` with comprehensive static analysis tests
- Tests verify the package and example implementations remain type-stable

## Changes

1. **Project.toml**: Added JET.jl to `[extras]` and `[targets]` as a test dependency with compat `JET = "0.9"`

2. **test/jet.jl**: New test file with:
   - Package-level analysis using `JET.report_package("SurrogatesBase")`
   - Type stability tests for `AbstractDeterministicSurrogate` implementations
   - Type stability tests for `AbstractStochasticSurrogate` implementations

3. **test/runtests.jl**: Added JET tests to the test suite

## JET Analysis Results

JET found no issues with the package:
- Package analysis: Clean (no type instabilities or potential runtime errors)
- Test implementations: All type-stable

## Test plan

- [x] Ran `Pkg.test()` locally - all tests pass
- [ ] CI should verify tests pass on all supported Julia versions

cc @ChrisRackauckas

🤖 Generated with [Claude Code](https://claude.com/claude-code)