### PR TITLE
Switch from JuliaFormatter to Runic.jl for code formatting

### DIFF
--- a/.JuliaFormatter.toml
+++ b/.JuliaFormatter.toml
@@ -1,1 +1,0 @@
-style = "sciml"

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -1,0 +1,19 @@
+name: format-check
+
+on:
+  push:
+    branches:
+      - 'master'
+      - 'main'
+      - 'release-'
+    tags: '*'
+  pull_request:
+
+jobs:
+  runic:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: fredrikekre/runic-action@v1
+        with:
+          version: '1'

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,8 +1,10 @@
 using Documenter, SurrogatesBase
 
-DocMeta.setdocmeta!(SurrogatesBase,
+DocMeta.setdocmeta!(
+    SurrogatesBase,
     :DocTestSetup,
-    :(using SurrogatesBase))
+    :(using SurrogatesBase)
+)
 
 cp("./docs/Manifest.toml", "./docs/src/assets/Manifest.toml", force = true)
 cp("./docs/Project.toml", "./docs/src/assets/Project.toml", force = true)
@@ -10,18 +12,22 @@ cp("./docs/Project.toml", "./docs/src/assets/Project.toml", force = true)
 pages = [
     "Home" => "index.md",
     "interface.md",
-    "api.md"
+    "api.md",
 ]
 
 ENV["GKSwstype"] = "100"
 
-makedocs(modules = [SurrogatesBase],
+makedocs(
+    modules = [SurrogatesBase],
     sitename = "SurrogatesBase.jl",
     clean = true,
     doctest = true,
     linkcheck = true,
-    format = Documenter.HTML(assets = ["assets/favicon.ico"],
-        canonical = "https://docs.sciml.ai/SurrogatesBase/stable/"),
-    pages = pages)
+    format = Documenter.HTML(
+        assets = ["assets/favicon.ico"],
+        canonical = "https://docs.sciml.ai/SurrogatesBase/stable/"
+    ),
+    pages = pages
+)
 
 deploydocs(repo = "github.com/SciML/SurrogatesBase.jl"; push_preview = true)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,7 +15,7 @@ end
 (s::DummySurrogate)(x) = s.ys[argmin(norm(x - ξ) for ξ in s.xs)]
 function SurrogatesBase.update!(s::DummySurrogate, new_xs, new_ys)
     append!(s.xs, new_xs)
-    append!(s.ys, new_ys)
+    return append!(s.ys, new_ys)
 end
 
 mutable struct HyperparameterDummySurrogate{X, Y} <: AbstractDeterministicSurrogate
@@ -27,14 +27,14 @@ end
 (s::HyperparameterDummySurrogate)(x) = s.ys[argmin(norm(x - ξ, s.θ.p) for ξ in s.xs)]
 function SurrogatesBase.update!(s::HyperparameterDummySurrogate, new_xs, new_ys)
     append!(s.xs, new_xs)
-    append!(s.ys, new_ys)
+    return append!(s.ys, new_ys)
 end
 
 SurrogatesBase.hyperparameters(s::HyperparameterDummySurrogate) = s.θ
 
 function SurrogatesBase.update_hyperparameters!(s::HyperparameterDummySurrogate, prior)
     # "hyperparmeter optimization"
-    s.θ = (; p = (s.θ.p + prior.p) / 2)
+    return s.θ = (; p = (s.θ.p + prior.p) / 2)
 end
 
 @testset "update!" begin
@@ -59,9 +59,11 @@ end
 
 @testset "hyperparameter interface" begin
     # use HyperparameterDummySurrogate
-    hd = HyperparameterDummySurrogate(Vector{Vector{Float64}}(),
+    hd = HyperparameterDummySurrogate(
+        Vector{Vector{Float64}}(),
         Vector{Float64}(),
-        (; p = 2))
+        (; p = 2)
+    )
     update!(hd, [[1.9, 2.1], [10.3, 0.1]], [5.0, 9.0])
 
     @test hyperparameters(hd).p == 2
@@ -78,7 +80,7 @@ function SurrogatesBase.update!(s::DummyStochasticSurrogate, new_xs, new_ys)
     append!(s.xs, new_xs)
     append!(s.ys, new_ys)
     # update mean
-    s.ys_mean = (s.ys_mean * (length(s.xs) - length(new_xs)) + sum(new_ys)) / length(s.xs)
+    return s.ys_mean = (s.ys_mean * (length(s.xs) - length(new_xs)) + sum(new_ys)) / length(s.xs)
 end
 
 SurrogatesBase.parameters(s::DummyStochasticSurrogate) = s.ys_mean
@@ -94,13 +96,15 @@ function FiniteDummyStochasticSurrogate(s, xs)
 end
 
 function SurrogatesBase.finite_posterior(s::DummyStochasticSurrogate, xs)
-    FiniteDummyStochasticSurrogate(s, xs)
+    return FiniteDummyStochasticSurrogate(s, xs)
 end
 
 @testset "finite_posterior, parameters" begin
     # use HyperparameterDummySurrogate
-    ss = DummyStochasticSurrogate(Vector{Vector{Float64}}(),
-        Vector{Float64}(), 0.0)
+    ss = DummyStochasticSurrogate(
+        Vector{Vector{Float64}}(),
+        Vector{Float64}(), 0.0
+    )
 
     update!(ss, [[1.9, 2.1], [10.3, 0.1]], [5.0, 9.0])
     # test parameters


### PR DESCRIPTION
## Summary
- Updated CI workflow to use `fredrikekre/runic-action@v1` instead of JuliaFormatter
- Removed `.JuliaFormatter.toml` configuration file
- Reformatted all source files with Runic.jl

## Changes
This PR migrates the code formatting from JuliaFormatter with SciMLStyle to Runic.jl. Runic.jl is an opinionated formatter (similar to Go's gofmt) that requires no configuration.

Key differences from JuliaFormatter:
- Explicit `return` statements are added where implicit
- Different indentation and alignment for continuation lines
- Consistent multiline formatting for function arguments

## Test plan
- [ ] CI format check passes with Runic.jl
- [ ] All existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)