### PR TITLE
Add AllocCheck allocation tests and CI job

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -37,3 +37,22 @@ jobs:
       julia-version: "${{ matrix.version }}"
       os: "${{ matrix.os }}"
     secrets: "inherit"
+
+  alloccheck:
+    name: "AllocCheck"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: julia-actions/setup-julia@v2
+        with:
+          version: "1"
+      - uses: julia-actions/cache@v2
+      - name: Run allocation tests
+        run: |
+          julia --project -e '
+            using Pkg
+            Pkg.instantiate()
+            Pkg.test()
+          '
+        env:
+          GROUP: nopre

--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Samuel Belko <samuelbelko@protonmail.com> and contributors"]
 version = "1.1.0"
 
 [compat]
+AllocCheck = "0.2"
 Aqua = "0.8"
 JET = "0.9, 0.10, 0.11"
 LinearAlgebra = "1.10"
@@ -13,6 +14,7 @@ Test = "1.10"
 julia = "1.10"
 
 [extras]
+AllocCheck = "9b6a8646-10ed-4001-bbdc-1d2f46dfbb1a"
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
@@ -21,4 +23,4 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "JET", "LinearAlgebra", "SafeTestsets", "Statistics", "Test"]
+test = ["AllocCheck", "Aqua", "JET", "LinearAlgebra", "SafeTestsets", "Statistics", "Test"]

--- a/test/alloc_tests.jl
+++ b/test/alloc_tests.jl
@@ -1,0 +1,70 @@
+using SurrogatesBase
+using AllocCheck
+using LinearAlgebra
+using Test
+
+# This file demonstrates allocation testing for surrogate implementations.
+# Since SurrogatesBase is an interface package with no concrete implementations,
+# these tests verify that example implementations can be allocation-free.
+
+# Simple allocation-free surrogate for testing
+struct AllocTestSurrogate{X, Y} <: AbstractDeterministicSurrogate
+    xs::Vector{X}
+    ys::Vector{Y}
+end
+
+# Allocation-free call - returns the closest y value using pre-computed indices
+function (s::AllocTestSurrogate)(x::Vector{Float64})
+    min_idx = 1
+    min_dist = Inf
+    @inbounds for i in eachindex(s.xs)
+        dist = zero(Float64)
+        xi = s.xs[i]
+        for j in eachindex(x)
+            diff = x[j] - xi[j]
+            dist += diff * diff
+        end
+        if dist < min_dist
+            min_dist = dist
+            min_idx = i
+        end
+    end
+    return @inbounds s.ys[min_idx]
+end
+
+@testset "AllocCheck - Surrogate Operations" begin
+    # Create surrogate with test data
+    xs = [Float64[1.0, 2.0], Float64[3.0, 4.0], Float64[5.0, 6.0]]
+    ys = [1, 2, 3]
+    s = AllocTestSurrogate(xs, ys)
+
+    # Test that calling the surrogate is allocation-free
+    x_test = Float64[2.0, 3.0]
+
+    # Verify correctness first
+    @test s(x_test) == 1  # Closest to [1.0, 2.0]
+
+    # Check that the call is allocation-free after warmup
+    s(x_test)  # warmup
+    allocs = @allocated s(x_test)
+    @test allocs == 0
+
+    # Test with @check_allocs macro
+    @check_allocs function test_surrogate_call(surr::AllocTestSurrogate{Vector{Float64}, Int}, x::Vector{Float64})
+        return surr(x)
+    end
+    @test test_surrogate_call(s, x_test) == 1
+end
+
+@testset "AllocCheck - Type Stability" begin
+    # Verify that abstract type checks are allocation-free
+    xs = [Float64[1.0, 2.0]]
+    ys = [1]
+    s = AllocTestSurrogate(xs, ys)
+
+    @check_allocs function check_type(surr::AllocTestSurrogate)
+        return surr isa AbstractDeterministicSurrogate
+    end
+
+    @test check_type(s) == true
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -117,3 +117,8 @@ end
     @test length(m) == 3
     @test m[1] ≈ parameters(ss)
 end
+
+# Run allocation tests in nopre group to avoid precompilation interference
+if get(ENV, "GROUP", "all") == "all" || get(ENV, "GROUP", "all") == "nopre"
+    @safetestset "Allocation Tests" include("alloc_tests.jl")
+end


### PR DESCRIPTION
## Summary

- Add `AllocCheck` to test dependencies for allocation testing
- Add `test/alloc_tests.jl` with example allocation-free surrogate implementation tests
- Add `alloccheck` CI job in Tests.yml running with `GROUP=nopre`

## Context

SurrogatesBase.jl is an interface package that defines abstract types (`AbstractDeterministicSurrogate`, `AbstractStochasticSurrogate`) and function stubs (`update!`, `parameters`, etc.). Since there are no concrete implementations to optimize, this PR adds allocation testing infrastructure that:

1. Serves as an example for downstream packages implementing surrogates
2. Demonstrates how to write allocation-free surrogate operations
3. Uses `@check_allocs` from AllocCheck.jl to verify zero allocations

The allocation tests run in a separate "nopre" group to avoid interference with precompilation.

## Test plan

- [x] All existing tests pass
- [x] New allocation tests pass with `GROUP=nopre`
- [ ] CI AllocCheck job runs successfully

cc @ChrisRackauckas

🤖 Generated with [Claude Code](https://claude.com/claude-code)