### PR TITLE
Centralize CI on SciML reusable workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,14 +5,10 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
-    ignore:
-      - dependency-name: "crate-ci/typos"
-        update-types: ["version-update:semver-patch", "version-update:semver-minor"]
   - package-ecosystem: "julia"
     directories:
       - "/"
       - "/docs"
-      - "/test"
     schedule:
       interval: "daily"
     groups:

--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -12,25 +12,15 @@ on:
       - 'docs/**'
 jobs:
   test:
-    runs-on: ubuntu-latest
+    name: "Downgrade"
     strategy:
       matrix:
         group:
           - Core
-        downgrade_mode: ['alldeps']
         julia-version: ['1.10']
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: ${{ matrix.julia-version }}
-      - uses: julia-actions/julia-downgrade-compat@v2
-#        if: ${{ matrix.version == '1.6' }}
-        with:
-          skip: Pkg,TOML
-      - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
-        with:
-          ALLOW_RERESOLVE: false
-        env:
-          GROUP: ${{ matrix.group }}
+    uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
+    with:
+      julia-version: "${{ matrix.julia-version }}"
+      group: "${{ matrix.group }}"
+      skip: "Pkg,TOML"
+    secrets: "inherit"

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -11,12 +11,6 @@ on:
 
 jobs:
   runic:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: '1'
-      - uses: fredrikekre/runic-action@v1
-        with:
-          version: '1'
+    name: "Runic"
+    uses: "SciML/.github/.github/workflows/runic.yml@v1"
+    secrets: "inherit"

--- a/.github/workflows/SpellCheck.yml
+++ b/.github/workflows/SpellCheck.yml
@@ -4,10 +4,6 @@ on: [pull_request]
 
 jobs:
   typos-check:
-    name: Spell Check with Typos
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Actions Repository
-        uses: actions/checkout@v6
-      - name: Check spelling
-        uses: crate-ci/typos@v1.16.23 
+    name: "Spell Check"
+    uses: "SciML/.github/.github/workflows/spellcheck.yml@v1"
+    secrets: "inherit"


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas.

Converts the CI to use the centralized SciML/.github reusable workflows (all pinned `@v1`, every caller gets `secrets: "inherit"`).

## Converted (inline -> central caller)
- **FormatCheck.yml**: `fredrikekre/runic-action` -> `runic.yml@v1`
- **SpellCheck.yml**: `crate-ci/typos` -> `spellcheck.yml@v1`
- **Downgrade.yml**: inline downgrade job -> `downgrade.yml@v1`, preserving the matrix exactly (`group: Core`, `julia-version: 1.10`, `skip: Pkg,TOML`; `ALLOW_RERESOLVE: false` is the caller default)

## Already central (left as-is)
- **Tests.yml**: already a `tests.yml@v1` caller (version × os matrix preserved). Retains its custom inline `AllocCheck` job (`GROUP: nopre`), which has no central equivalent.
- **Documentation.yml**: already a `documentation.yml@v1` caller.

## Cleanup
- **dependabot.yml**: removed the `crate-ci/typos` ignore block (spellcheck is now centralized); removed the `/test` julia directory entry (no `Project.toml` there). `github-actions` (weekly, `/`) and `julia` (daily, group `all-julia-packages: ["*"]` over `/`, `/docs`) blocks retained.
- No CompatHelper workflow present.
- TagBot.yml unchanged.

## Checks
- **Runic**: ran `Runic.main(["--inplace","."])` locally — no changes (repo was already Runic-clean from the prior inline check).
- **Typos**: `typos .` exits 0 — no fixes needed.

⚠️ Check names will change (e.g. the format/spellcheck/downgrade job names now come from the reusable workflows), so any branch-protection required-status-check names will need updating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)