### PR TITLE
Skip AllocCheck tests on prerelease Julia

### DIFF
--- a/test/alloc_tests.jl
+++ b/test/alloc_tests.jl
@@ -32,39 +32,45 @@ function (s::AllocTestSurrogate)(x::Vector{Float64})
     return @inbounds s.ys[min_idx]
 end
 
-@testset "AllocCheck - Surrogate Operations" begin
-    # Create surrogate with test data
-    xs = [Float64[1.0, 2.0], Float64[3.0, 4.0], Float64[5.0, 6.0]]
-    ys = [1, 2, 3]
-    s = AllocTestSurrogate(xs, ys)
+# AllocCheck builds on GPUCompiler/LLVM compiler internals, which are unstable on
+# Julia prereleases (the RC codegen reports a spurious allocation that does not appear
+# on released Julia). Only run these checks on released Julia, matching the original
+# GROUP=nopre scoping of this file.
+if isempty(VERSION.prerelease)
+    @testset "AllocCheck - Surrogate Operations" begin
+        # Create surrogate with test data
+        xs = [Float64[1.0, 2.0], Float64[3.0, 4.0], Float64[5.0, 6.0]]
+        ys = [1, 2, 3]
+        s = AllocTestSurrogate(xs, ys)
 
-    # Test that calling the surrogate is allocation-free
-    x_test = Float64[2.0, 3.0]
+        # Test that calling the surrogate is allocation-free
+        x_test = Float64[2.0, 3.0]
 
-    # Verify correctness first
-    @test s(x_test) == 1  # Closest to [1.0, 2.0]
+        # Verify correctness first
+        @test s(x_test) == 1  # Closest to [1.0, 2.0]
 
-    # Check that the call is allocation-free after warmup
-    s(x_test)  # warmup
-    allocs = @allocated s(x_test)
-    @test allocs == 0
+        # Check that the call is allocation-free after warmup
+        s(x_test)  # warmup
+        allocs = @allocated s(x_test)
+        @test allocs == 0
 
-    # Test with @check_allocs macro
-    @check_allocs function test_surrogate_call(surr::AllocTestSurrogate{Vector{Float64}, Int}, x::Vector{Float64})
-        return surr(x)
-    end
-    @test test_surrogate_call(s, x_test) == 1
-end
-
-@testset "AllocCheck - Type Stability" begin
-    # Verify that abstract type checks are allocation-free
-    xs = [Float64[1.0, 2.0]]
-    ys = [1]
-    s = AllocTestSurrogate(xs, ys)
-
-    @check_allocs function check_type(surr::AllocTestSurrogate)
-        return surr isa AbstractDeterministicSurrogate
+        # Test with @check_allocs macro
+        @check_allocs function test_surrogate_call(surr::AllocTestSurrogate{Vector{Float64}, Int}, x::Vector{Float64})
+            return surr(x)
+        end
+        @test test_surrogate_call(s, x_test) == 1
     end
 
-    @test check_type(s) == true
+    @testset "AllocCheck - Type Stability" begin
+        # Verify that abstract type checks are allocation-free
+        xs = [Float64[1.0, 2.0]]
+        ys = [1]
+        s = AllocTestSurrogate(xs, ys)
+
+        @check_allocs function check_type(surr::AllocTestSurrogate)
+            return surr isa AbstractDeterministicSurrogate
+        end
+
+        @test check_type(s) == true
+    end
 end


### PR DESCRIPTION
## Problem

The `main` CI is red on the single check **`tests / Core (julia pre, macos-latest)`** (Julia 1.13.0-rc1, aarch64-macOS). All other matrix entries (lts, 1, and `pre` on ubuntu/windows) are green.

The failure is in `test/alloc_tests.jl`:

```
@check_allocs function encountered 1 errors (1 allocations / 0 dynamic dispatches).
Expression: test_surrogate_call(s, x_test) == 1
```

## Root cause

`test/alloc_tests.jl` was originally added (commit 43917ab) on a **dedicated CI job scoped to `ubuntu-latest`, Julia `"1"` only, with `GROUP=nopre`** — deliberately excluding prereleases, because AllocCheck builds on GPUCompiler/LLVM compiler internals that are unstable on Julia prereleases.

The CI centralization to the SciMLTesting v1.2 folder-based `run_tests()` harness (#36) discovers every top-level `test/*.jl` as part of the `Core` group and runs it across the full `versions × os` matrix declared in `test/test_groups.toml` (`["lts", "1", "pre"]` × 3 OSes). That dropped the original `nopre` / single-runner scoping, so `alloc_tests.jl` now runs on `pre` (1.13.0-rc1), where `@check_allocs` reports a spurious allocation on aarch64-macOS.

## Fix

Gate the two AllocCheck testsets on `isempty(VERSION.prerelease)`, restoring the original `nopre` intent. Full AllocCheck coverage is retained on every released Julia.

## Local verification

Ran `test/alloc_tests.jl` with `--check-bounds=yes` (matching CI):

- **lts (1.10.11):** AllocCheck tests run and pass — 3/3 and 1/1
- **1 / stable (1.12.6):** AllocCheck tests run and pass — 3/3 and 1/1
- **pre (1.13.0-rc1):** file is a clean no-op, no errors

(The aarch64-specific spurious-alloc failure could not be reproduced directly — no aarch64 hardware available — but on x86_64-linux 1.13.0-rc1 the test passes, matching the green `pre, ubuntu-latest` CI entry; the gate removes the prerelease channel entirely, which is where the instability lives.)

Runic formatting: clean (no diff).

---

Please ignore until reviewed by @ChrisRackauckas.